### PR TITLE
Remove bad links controlled vocabs

### DIFF
--- a/docs/tables/controlled-vocabularies-to-be-used.html
+++ b/docs/tables/controlled-vocabularies-to-be-used.html
@@ -78,30 +78,6 @@
             <td>&nbsp;</td>
         </tr>
 
-
-        <!-- Conforms to -->
-
-        <tr>
-            <td>
-                <p>+<code>dct:conformsTo</code></p>
-            </td>
-            <td>
-                <p><a href="#data-service-conforms_to">Data Service</a></p>
-                <p><a href="#dataset-conforms_to">Dataset</a></p>
-                <p><a href="#distribution-conforms_to">Distribution</a></p>
-                <p><a href="#data-service-conforms_to">Data Service</a></p>
-            </td>
-            <td>
-                <p>OGC EPSG Coordinate Reference Systems Register [[OGC-EPSG]]</p>
-            </td>
-            <td>
-                <p><a href="http://www.opengis.net/def/crs/EPSG/0/">http://www.opengis.net/def/crs/EPSG/0/</a></p>
-            </td>
-            <td>&nbsp;</td>
-        </tr>
-
-    
-
         <!-- Language -->
 
         <tr>


### PR DESCRIPTION
Directly related to https://github.com/GSA/dcat-us/issues/37.

Removes bad entries that aren't defined and don't go anywhere.

Also removes a bad list for the conformsTo field, as this shouldn't be a canonical list (by definition this is open ended to define the schema/definition/type that the data or metadata follows).