### PR TITLE
Allow singular contact point, don't enforce array list.

### DIFF
--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -131,6 +131,15 @@
                     "type": "null"
                 },
                 {
+                    "$ref": "#/definitions/Kind",
+                    "description": "inline description of Kind"
+                },
+                {
+                    "type": "string",
+                    "description": "reference iri of Kind",
+                    "format": "iri"
+                },
+                {
                     "type": "array",
                     "items": {
                         "oneOf": [
@@ -606,18 +615,18 @@
                 {
                     "type": "array",
                     "items": {
-						"oneOf": [
-							{
-								"$ref": "#/definitions/Standard",
-								"description": "inline description of Standard"
-							},
-							{
-								"type": "string",
-								"description": "reference iri of Standard",
-								"format": "iri"
-							}
-						]
-					}
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Standard",
+                                "description": "inline description of Standard"
+                            },
+                            {
+                                "type": "string",
+                                "description": "reference iri of Standard",
+                                "format": "iri"
+                            }
+                        ]
+                    }
                 }
             ]
         },
@@ -1189,17 +1198,17 @@
                 {
                     "type": "array",
                     "items": {
-                       "oneOf": [
-                           {
-                               "$ref": "#/definitions/Document",
-                               "description": "inline description of Document"
-                           },
-                           {
-                               "type": "string",
-                               "description": "reference iri of Document",
-                               "format": "iri"
-                           }
-                       ]
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Document",
+                                "description": "inline description of Document"
+                            },
+                            {
+                                "type": "string",
+                                "description": "reference iri of Document",
+                                "format": "iri"
+                            }
+                        ]
                     }
                 }
             ]


### PR DESCRIPTION
Supports more backward compatibility.

Related to https://github.com/GSA/dcat-us/issues/26, would address.