### PR TITLE
Make keyword an array of strings.

### DIFF
--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -281,7 +281,11 @@
                     "type": "null"
                 },
                 {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    }
                 }
             ]
         },
@@ -606,18 +610,18 @@
                 {
                     "type": "array",
                     "items": {
-						"oneOf": [
-							{
-								"$ref": "#/definitions/Standard",
-								"description": "inline description of Standard"
-							},
-							{
-								"type": "string",
-								"description": "reference iri of Standard",
-								"format": "iri"
-							}
-						]
-					}
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Standard",
+                                "description": "inline description of Standard"
+                            },
+                            {
+                                "type": "string",
+                                "description": "reference iri of Standard",
+                                "format": "iri"
+                            }
+                        ]
+                    }
                 }
             ]
         },
@@ -1189,17 +1193,17 @@
                 {
                     "type": "array",
                     "items": {
-                       "oneOf": [
-                           {
-                               "$ref": "#/definitions/Document",
-                               "description": "inline description of Document"
-                           },
-                           {
-                               "type": "string",
-                               "description": "reference iri of Document",
-                               "format": "iri"
-                           }
-                       ]
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Document",
+                                "description": "inline description of Document"
+                            },
+                            {
+                                "type": "string",
+                                "description": "reference iri of Document",
+                                "format": "iri"
+                            }
+                        ]
                     }
                 }
             ]


### PR DESCRIPTION
This should resolve https://github.com/GSA/dcat-us/issues/27.

Keyword field has always been meant as an array of keywords, and we should leave it as such.

Not bringing forward the requirement that keyword exist and have at least 1 entry from 1.1.

We are enforcing that an empty string is not allowed as a keyword, it must contain at least 1 character.