### PR TITLE
Refactor 'source' definition in Dataset.json

### DIFF
--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -1011,7 +1011,7 @@
         "source": {
             "$id": "http://purl.org/dc/terms/source",
             "title": "data source",
-            "description": "Reference to the source of the dataset",
+            "description": "A related Dataset from which the described Dataset is derived",
             "oneOf": [
                 {
                     "type": "null"
@@ -1021,12 +1021,12 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/Resource",
-                                "description": "inline description of Resource"
+                                "$ref": "#/definitions/Dataset",
+                                "description": "inline description of Dataset"
                             },
                             {
                                 "type": "string",
-                                "description": "reference iri of Resource",
+                                "description": "reference iri of Dataset",
                                 "format": "iri"
                             }
                         ]


### PR DESCRIPTION
Updated the 'source' definition to include either inline descriptions of a 'Dataset' or a reference iri of a 'Dataset.' This replaces references to the 'Resource' class as it is not defined, and also aligns with the [DOI DCAT-US 3.0 documentation](https://doi-do.github.io/dcat-us/#dataset-source), which lists the 'source' range as 'dcat:Dataset'

Related to/addressing #10 