### PR TITLE
Refactor 'relation' and 'isReferencedBy' definitions in Dataset.json

### DIFF
--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -766,17 +766,9 @@
                 {
                     "type": "array",
                     "items": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/definitions/Resource",
-                                "description": "inline description of Resource"
-                            },
-                            {
-                                "type": "string",
-                                "description": "reference iri of Resource",
-                                "format": "iri"
-                            }
-                        ]
+                        "type": "string",
+                        "description": "reference iri of Resource",
+                        "format": "iri"
                     }
                 }
             ]
@@ -910,7 +902,7 @@
         "relation": {
             "$id": "http://purl.org/dc/terms/relation",
             "title": "related resource",
-            "description": "Reference to a related source",
+            "description": "Reference to a related resource",
             "oneOf": [
                 {
                     "type": "null"
@@ -918,17 +910,9 @@
                 {
                     "type": "array",
                     "items": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/definitions/Resource",
-                                "description": "inline description of Resource"
-                            },
-                            {
-                                "type": "string",
-                                "description": "reference iri of Resource",
-                                "format": "iri"
-                            }
-                        ]
+                        "type": "string",
+                        "description": "reference iri of Resource",
+                        "format": "iri"
                     }
                 }
             ]


### PR DESCRIPTION
Updated the 'relation' and 'isReferencedBy' definitions to remove references to the 'Resource' class, which doesn't exist. Both should look like an identifier and an IRI.

Related to/addressing #8 and #9.

In conjunction with #50, should resolve all issues regarding references to the 'Resource' class within the 'Dataset.json' file.