### PR TITLE
Update CatalogRecord primaryTopic field

### DIFF
--- a/jsonschema/definitions/CatalogRecord.json
+++ b/jsonschema/definitions/CatalogRecord.json
@@ -201,17 +201,7 @@
             "$id": "http://xmlns.com/foaf/0.1/primaryTopic",
             "title": "primary topic",
             "description": "A link to the Dataset, Data service or Catalog described in the Catalog Record.",
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/Resource",
-                    "description": "inline description of Resource"
-                },
-                {
-                    "type": "string",
-                    "description": "reference iri of Resource",
-                    "format": "iri"
-                }
-            ]
+            "type": "string"
         }
     },
     "required": [


### PR DESCRIPTION
The resource type doesn't exist. Allow this to be a free-form string, as it may represent an ID or other reference to document that is not an IRI.

Resolves https://github.com/GSA/dcat-us/issues/5

References:
- https://w3c.github.io/dxwg/dcat3-implementation-report/#proposed-revisions
- https://infopolicy.github.io/dcat-us/#catalog-record-primaryTopic