### PR TITLE
Refactor 'unitMeasure' definition in QualityMeasurement.json

### DIFF
--- a/jsonschema/definitions/QualityMeasurement.json
+++ b/jsonschema/definitions/QualityMeasurement.json
@@ -42,17 +42,7 @@
                     "type": "null"
                 },
                 {
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/Resource",
-                            "description": "inline description of Resource"
-                        },
-                        {
-                            "type": "string",
-                            "description": "reference iri of Resource",
-                            "format": "iri"
-                        }
-                    ]
+                    "type": "string"
                 }
             ]
         }


### PR DESCRIPTION
Updated the 'unitMeasure' definition to allow any string. Removed references to 'Resource' class, which isn't defined. 

[DOI DCAT-US 3.0 Documentation](https://doi-do.github.io/dcat-us/#quality_measurement_unit_measure)

**Previous work:** https://github.com/GSA/dcat-us3-tools/commit/0b872ec265ccd548cf9319b0a0eacceafafd5318

**Related to/addressing:** #14 