### PR TITLE
Refactor 'accessURL' and 'downloadURL' definitions in Distribution.json

### DIFF
--- a/jsonschema/definitions/Distribution.json
+++ b/jsonschema/definitions/Distribution.json
@@ -108,17 +108,9 @@
                     "type": "null"
                 },
                 {
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/Resource",
-                            "description": "inline description of Resource"
-                        },
-                        {
-                            "type": "string",
-                            "description": "reference iri of Resource",
-                            "format": "iri"
-                        }
-                    ]
+                    "type": "string",
+                    "description": "reference iri of Resource",
+                    "format": "iri"
                 }
             ]
         },
@@ -161,23 +153,15 @@
         "downloadURL": {
             "$id": "http://www.w3.org/ns/dcat#downloadURL",
             "title": "download URL",
-            "description": "A URL that is a direct link to a downloadable file in a given format.",
+            "description": "A URL that is a direct link to a downloadable file of the Distribution in a given format.",
             "oneOf": [
                 {
                     "type": "null"
                 },
                 {
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/Resource",
-                            "description": "inline description of Resource"
-                        },
-                        {
-                            "type": "string",
-                            "description": "reference iri of Resource",
-                            "format": "iri"
-                        }
-                    ]
+                    "type": "string",
+                    "description": "reference iri of Resource",
+                    "format": "iri"
                 }
             ]
         },


### PR DESCRIPTION
Updated the 'accessURL' and 'downloadURL' definitions to remove references to the 'Resource' class, which doesn't exist. Both should accept strings that look like an identifier/IRI for a Resource.

**DOI DCAT-US 3.0 Documentation:** [Distribution - accessURL](https://doi-do.github.io/dcat-us/#distribution-access-url), [Distribution - downloadURL](https://doi-do.github.io/dcat-us/#distribution-download-url)

**Previous work:** https://github.com/GSA/dcat-us3-tools/commit/2dd39a0ef0ae40daf2f2d04a4996d4ed048b3f72

**Related to/addressing:** #11 and #12 