### PR TITLE
Refactor 'tel' definition in Kind.json

### DIFF
--- a/jsonschema/definitions/Kind.json
+++ b/jsonschema/definitions/Kind.json
@@ -98,17 +98,7 @@
                     "type": "null"
                 },
                 {
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/Resource",
-                            "description": "inline description of Resource"
-                        },
-                        {
-                            "type": "string",
-                            "description": "reference iri of Resource",
-                            "format": "iri"
-                        }
-                    ]
+                    "type": "string"
                 }
             ]
         },


### PR DESCRIPTION
I agree with James's past work. Updated the 'tel' definition in Kind.json (i.e., vcard:Kind - represents a 'Point of Contact') to remove references to the 'Resource' class, which doesn't exist. It should instead just be a string, as the field is sparsely populated and different phone services throughout the world use different conventions.

**DOI DCAT-US 3.0 Documentation:** [Contact/Kind - tel](https://doi-do.github.io/dcat-us/#contact-tel)

**Previous work:** https://github.com/GSA/dcat-us3-tools/commit/33738264cda222a4d1c1e895562db1a1fe11fd01

**Related to/addressing:** #13 