### PR TITLE
Refactor 'relation' definition in Relationship.json

### DIFF
--- a/jsonschema/definitions/Relationship.json
+++ b/jsonschema/definitions/Relationship.json
@@ -31,17 +31,8 @@
             "$id": "http://purl.org/dc/terms/relation",
             "title": "relation",
             "description": "The resource related to the source resource.",
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/Resource",
-                    "description": "inline description of Resource"
-                },
-                {
-                    "type": "string",
-                    "description": "reference iri of Resource",
-                    "format": "iri"
-                }
-            ]
+            "type": "string",
+            "format": "iri"
         }
     },
     "required": [


### PR DESCRIPTION
I agree with James's past work. Updated the 'relation' definition in Relationship.json to remove references to the 'Resource' class, which doesn't exist. It should accept strings that look like an identifier/IRI for another asset/resource.

**DOI DCAT-US 3.0 Documentation:** [Relationship - relation](https://doi-do.github.io/dcat-us/#relationship-relation)

**Previous work:** https://github.com/GSA/dcat-us3-tools/commit/49d062b8d36a95bcc1ad2d28c482f3bdb387aecd

**Related to/addressing:** #15 