### PR TITLE
Update JSON schema per documentation for periodicity.

### DIFF
--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -585,16 +585,49 @@
                     "type": "null"
                 },
                 {
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/Frequency",
-                            "description": "inline description of Frequency"
-                        },
-                        {
-                            "type": "string",
-                            "description": "reference iri of Frequency",
-                            "format": "iri"
-                        }
+                    "type": "string",
+                    "description": "ISO 19115 Maintenance Frequency code, see https://infopolicy.github.io/dcat-us/#frequency-coding",
+                    "enum": [
+                        "continual",
+                        "daily",
+                        "weekly",
+                        "fortnightly",
+                        "monthly",
+                        "quarterly",
+                        "biannually",
+                        "annually",
+                        "asNeeded",
+                        "irregular",
+                        "notPlanned",
+                        "unknown"
+                    ]
+                },
+                {
+                    "type": "string",
+                    "description": "ISO-8601 Maintenance Frequency code for recurring values, see https://infopolicy.github.io/dcat-us/#frequency-coding",
+                    "pattern": "^R\/P.+$"
+                },
+                {
+                    "type": "string",
+                    "description": "Dublin Core Collection Frequency Vocabulary, see https://infopolicy.github.io/dcat-us/#frequency-coding",
+                    "enum": [
+                        "continuous",
+                        "daily",
+                        "weekly",
+                        "biweekly",
+                        "monthly",
+                        "quarterly",
+                        "semiannual",
+                        "annual",
+                        "irregular",
+                        "triennial",
+                        "biennial",
+                        "threeTimesAYear",
+                        "bimonthly",
+                        "semimonthly",
+                        "threeTimesAMonth",
+                        "semiweekly",
+                        "threeTimesAWeek"
                     ]
                 }
             ]

--- a/jsonschema/examples/Dataset/good/dataset-complete-example.json
+++ b/jsonschema/examples/Dataset/good/dataset-complete-example.json
@@ -1,0 +1,278 @@
+{
+  "$schema": "../dcat_us_3.0.0_schema.json",
+  "@id": "https://data.gov/dataset/national-water-quality-assessment-2024",
+  "@type": "Dataset",
+  "title": "National Water Quality Assessment 2024",
+  "titleMap": {
+    "es": "Evaluación Nacional de la Calidad del Agua 2024",
+    "fr": "Évaluation Nationale de la Qualité de l'Eau 2024"
+  },
+  "description": "This dataset contains comprehensive water quality measurements collected from monitoring stations across the United States during fiscal year 2024. Data includes measurements of pH levels, dissolved oxygen, turbidity, temperature, and various chemical contaminants. The assessment supports the Clean Water Act requirements and provides critical data for environmental policy decisions.",
+  "descriptionMap": {
+    "es": "Este conjunto de datos contiene mediciones integrales de calidad del agua recopiladas de estaciones de monitoreo en todo Estados Unidos durante el año fiscal 2024."
+  },
+  "publisher": {
+    "@id": "https://www.epa.gov",
+    "@type": "Organization",
+    "name": "U.S. Environmental Protection Agency",
+    "subOrganizationOf": [
+      {
+        "@id": "https://www.usa.gov",
+        "@type": "Organization",
+        "name": "United States Government"
+      }
+    ]
+  },
+  "identifier": [
+    "EPA-WQ-2024-001",
+    "doi:10.5066/EPA-WQ-2024"
+  ],
+  "otherIdentifier": [
+    {
+      "@type": "Identifier",
+      "notation": "EPA-WQ-2024-001",
+      "schemaAgency": "https://www.epa.gov"
+    }
+  ],
+  "issued": "2024-01-15",
+  "created": "2023-06-01",
+  "modified": "2024-11-20T14:30:00Z",
+  "language": "en",
+  "version": "2.1.0",
+  "versionNotes": "Updated with Q3 2024 data. Fixed data quality issues in Pacific Northwest stations.",
+  "accrualPeriodicity": "quarterly",
+  "purpose": "To monitor and assess the quality of surface water and groundwater resources across the United States, supporting regulatory compliance and environmental protection efforts.",
+  "purposeMap": {
+    "es": "Monitorear y evaluar la calidad de los recursos de agua superficial y subterránea en todo Estados Unidos."
+  },
+  "keyword": [
+    "water quality",
+    "environmental monitoring",
+    "clean water",
+    "pH levels",
+    "dissolved oxygen",
+    "turbidity",
+    "groundwater",
+    "surface water"
+  ],
+  "keywordMap": {
+    "es": "calidad del agua, monitoreo ambiental, agua limpia"
+  },
+  "theme": [
+    {
+      "@id": "https://data.gov/vocab/themes/environment",
+      "@type": "Concept",
+      "prefLabel": "Environment",
+      "definition": "Environmental data and resources"
+    },
+    {
+      "@id": "https://data.gov/vocab/themes/geospatial",
+      "@type": "Concept",
+      "prefLabel": "Geospatial"
+    }
+  ],
+  "category": [
+    {
+      "@id": "https://data.gov/vocab/categories/water-resources",
+      "@type": "Concept",
+      "prefLabel": "Water Resources"
+    }
+  ],
+  "subject": [
+    {
+      "@id": "http://id.loc.gov/authorities/subjects/sh85145447",
+      "@type": "Concept",
+      "prefLabel": "Water quality"
+    }
+  ],
+  "contactPoint": [
+    {
+      "@type": "Kind",
+      "fn": "Water Quality Data Team",
+      "hasEmail": "mailto:waterquality@epa.gov",
+      "organization-name": "Office of Water"
+    }
+  ],
+  "creator": {
+    "@id": "https://www.epa.gov/water-research",
+    "@type": "Organization",
+    "name": "Office of Water Research"
+  },
+  "contributor": [
+    {
+      "@id": "https://www.usgs.gov",
+      "@type": "Organization",
+      "name": "U.S. Geological Survey"
+    }
+  ],
+  "rightsHolder": [
+    {
+      "@id": "https://www.epa.gov",
+      "@type": "Organization",
+      "name": "U.S. Environmental Protection Agency"
+    }
+  ],
+  "spatial": [
+    {
+      "@id": "http://id.loc.gov/authorities/names/n78095330",
+      "@type": "Location",
+      "prefLabel": "United States"
+    }
+  ],
+  "geographicBoundingBox": [
+    {
+      "@type": "GeographicBoundingBox",
+      "westBoundingLongitude": -124.848974,
+      "eastBoundingLongitude": -66.885444,
+      "southBoundingLatitude": 24.396308,
+      "northBoundingLatitude": 49.384358
+    }
+  ],
+  "temporal": [
+    {
+      "@type": "PeriodOfTime",
+      "startDate": "2024-01-01",
+      "endDate": "2024-09-30"
+    }
+  ],
+  "temporalResolution": "P1D",
+  "spatialResolutionInMeters": "100",
+  "distribution": [
+    {
+      "@id": "https://data.gov/dataset/national-water-quality-assessment-2024/distribution/csv",
+      "@type": "Distribution",
+      "title": "Water Quality Data CSV Export",
+      "description": "Full dataset in CSV format for easy analysis and import into spreadsheet applications.",
+      "downloadURL": "https://data.epa.gov/downloads/water-quality-2024.csv",
+      "mediaType": "text/csv",
+      "byteSize": "245678901",
+      "format": "CSV"
+    },
+    {
+      "@id": "https://data.gov/dataset/national-water-quality-assessment-2024/distribution/json",
+      "@type": "Distribution",
+      "title": "Water Quality Data JSON API",
+      "description": "RESTful API access to water quality data in JSON format.",
+      "accessURL": "https://api.epa.gov/water-quality/v2",
+      "mediaType": "application/json",
+      "format": "JSON"
+    },
+    {
+      "@id": "https://data.gov/dataset/national-water-quality-assessment-2024/distribution/geojson",
+      "@type": "Distribution",
+      "title": "Water Quality Monitoring Stations GeoJSON",
+      "description": "Geospatial data of monitoring station locations with associated measurements.",
+      "downloadURL": "https://data.epa.gov/downloads/water-quality-stations-2024.geojson",
+      "mediaType": "application/geo+json",
+      "format": "GeoJSON"
+    }
+  ],
+  "landingPage": {
+    "@id": "https://www.epa.gov/waterdata/national-water-quality-assessment-2024",
+    "@type": "Document",
+    "title": "National Water Quality Assessment 2024 Landing Page"
+  },
+  "page": [
+    {
+      "@id": "https://www.epa.gov/waterdata/documentation",
+      "@type": "Document",
+      "title": "Water Quality Assessment Documentation"
+    }
+  ],
+  "describedBy": {
+    "@id": "https://data.epa.gov/data-dictionary/water-quality-2024.xlsx",
+    "@type": "Distribution",
+    "title": "Water Quality Data Dictionary",
+    "downloadURL": "https://data.epa.gov/data-dictionary/water-quality-2024.xlsx",
+    "mediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+  },
+  "conformsTo": [
+    {
+      "@id": "https://www.iso.org/standard/53798.html",
+      "@type": "Standard",
+      "title": "ISO 19115-1:2014",
+      "description": "Geographic information — Metadata"
+    }
+  ],
+  "accessRights": {
+    "@type": "RightsStatement",
+    "label": "Public",
+    "description": "This dataset is available to the public with no restrictions on access."
+  },
+  "rights": {
+    "@type": "RightsStatement",
+    "label": "Public Domain",
+    "description": "This data is in the public domain and may be freely used, distributed, and modified."
+  },
+  "liabilityStatement": {
+    "@type": "LiabilityStatement",
+    "label": "Standard Government Liability",
+    "description": "This data is provided as-is. The U.S. Government makes no warranties, expressed or implied, regarding the accuracy or completeness of this data."
+  },
+  "provenance": [
+    {
+      "@type": "ProvenanceStatement",
+      "label": "Data Collection Methodology",
+      "description": "Data collected from over 2,500 automated monitoring stations using EPA-approved sampling methods and quality assurance protocols."
+    }
+  ],
+  "qualifiedAttribution": [
+    {
+      "@type": "Attribution",
+      "agent": {
+        "@id": "https://www.epa.gov/water-research",
+        "@type": "Organization",
+        "name": "Office of Water Research"
+      },
+      "hadRole": "http://registry.it.csiro.au/def/isotc211/CI_RoleCode/author"
+    }
+  ],
+  "wasGeneratedBy": [
+    {
+      "@type": "Activity",
+      "title": "National Water Quality Monitoring Program FY2024",
+      "description": "Annual water monitoring and data collection program"
+    }
+  ],
+  "hasQualityMeasurement": [
+    {
+      "@type": "QualityMeasurement",
+      "isMeasurementOf": {
+        "@id": "http://www.w3.org/ns/dqv#completeness",
+        "@type": "Concept",
+        "prefLabel": "Completeness"
+      },
+      "value": "98.5"
+    }
+  ],
+  "status": {
+    "@id": "http://purl.org/adms/status/Completed",
+    "@type": "Concept",
+    "prefLabel": "Completed"
+  },
+  "inSeries": [
+    {
+      "@id": "https://data.gov/dataset-series/national-water-quality-assessment",
+      "@type": "DatasetSeries",
+      "title": "National Water Quality Assessment Series"
+    }
+  ],
+  "relation": [
+    "https://data.gov/dataset/water-infrastructure-assessment-2024"
+  ],
+  "isReferencedBy": [
+    "https://www.epa.gov/reports/annual-water-quality-report-2024"
+  ],
+  "image": [
+    {
+      "@id": "https://www.epa.gov/images/water-quality-map-2024.png",
+      "@type": "ImageObject",
+      "contentUrl": "https://www.epa.gov/images/water-quality-map-2024.png",
+      "description": "Thumbnail map showing water quality assessment coverage"
+    }
+  ],
+  "scopeNote": "This dataset should be used in conjunction with the EPA Water Quality Standards database for regulatory interpretation. Data from some stations may have collection gaps due to equipment maintenance.",
+  "scopeNoteMap": {
+    "es": "Este conjunto de datos debe utilizarse junto con la base de datos de Estándares de Calidad del Agua de la EPA."
+  }
+}


### PR DESCRIPTION
Plans to resolve https://github.com/GSA/dcat-us/issues/16, and address comments.

I agree @zopalmer14 , this shouldn't be any string. I've limited it to the lists from the different standards, and linked to the documentation in the JSON schema description. Because ISO-8601 is so open and contains so many possibilities, I decided to allow "recurring" type strings but to allow any number or value type without getting too in the weeds on what could possibly be implemented (months, days, time seconds, etc).

I think this should stay in draft until we can run a good and bad example through. I tried running the test, but because there are still too many bad references (and Dataset object references many/most of the various object types) the tests can't run on dataset. Need further changes before we revisit this.