### PR TITLE
Remove custom object definition, and simply provide URL to image.

### DIFF
--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -1300,20 +1300,9 @@
                     "type": "null"
                 },
                 {
-                    "type": "array",
-                    "items": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/definitions/ImageObject",
-                                "description": "inline description of ImageObject"
-                            },
-                            {
-                                "type": "string",
-                                "description": "reference iri of ImageObject",
-                                "format": "iri"
-                            }
-                        ]
-                    }
+                    "type": "string",
+                    "description": "The link to the image",
+                    "format": "iri"
                 }
             ]
         },

--- a/jsonschema/definitions/Distribution.json
+++ b/jsonschema/definitions/Distribution.json
@@ -690,20 +690,9 @@
                     "type": "null"
                 },
                 {
-                    "type": "array",
-                    "items": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/definitions/ImageObject",
-                                "description": "inline description of ImageObject"
-                            },
-                            {
-                                "type": "string",
-                                "description": "reference iri of ImageObject",
-                                "format": "iri"
-                            }
-                        ]
-                    }
+                    "type": "string",
+                    "description": "The link to the image",
+                    "format": "iri"
                 }
             ]
         },


### PR DESCRIPTION
Should resolve https://github.com/GSA/dcat-us/issues/18.

This referenced a non-existent class, ImageObject. This removes that reference, and forces image field to be either null or a URL to an image.

I don't believe any other metadata information is really necessary around images, and I don't anticipate this field is highly utilized.