### PR TITLE
Fix Bug endpointURL referencing "Resource" object

### DIFF
--- a/jsonschema/definitions/DataService.json
+++ b/jsonschema/definitions/DataService.json
@@ -62,17 +62,9 @@
             "description": "The root location or primary endpoint of the service (a Web-resolvable IRI)",
             "type": "array",
             "items": {
-                "oneOf": [
-                    {
-                        "$ref": "#/definitions/Resource",
-                        "description": "inline description of Resource"
-                    },
-                    {
-                        "type": "string",
-                        "description": "reference iri of Resource",
-                        "format": "iri"
-                    }
-                ]
+                "type": "string",
+                "description": "The root location or primary endpoint of the service (a Web-resolvable IRI)",
+                "format": "iri"
             }
         },
         "keyword": {


### PR DESCRIPTION
Should resolve https://github.com/GSA/dcat-us/issues/7

endpointURL is defined as the main URL, it shouldn't be a reference to anything but the actual URL string value. Removes the bad references and forces URI (basically URL) string values.