### PR TITLE
Remove 'hasPolicy' definition in DataService.json

### DIFF
--- a/jsonschema/definitions/DataService.json
+++ b/jsonschema/definitions/DataService.json
@@ -603,32 +603,6 @@
                 }
             ]
         },
-        "hasPolicy": {
-            "$id": "http://www.w3.org/ns/odrl/2/hasPolicy",
-            "title": "has policy",
-            "description": "An ODRL conformant policy expressing the rights associated with the Data Service.",
-            "oneOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/definitions/Policy",
-                                "description": "inline description of Policy"
-                            },
-                            {
-                                "type": "string",
-                                "description": "reference iri of Policy",
-                                "format": "iri"
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
         "qualifiedAttribution": {
             "$id": "http://www.w3.org/ns/prov#qualifiedAttribution",
             "title": "qualified attribution",


### PR DESCRIPTION
I agree with James. Removed the entirety of the `hasPolicy` property in `DataService.json` as it both references a `Policy` class that doesn't exist, and the property is never mentioned on the DOI DCAT-US 3.0 website/documentation.

**DOI DCAT-US 3.0 Documentation:** [DataService](https://doi-do.github.io/dcat-us/#properties-for-data-service)

**Previous work:** https://github.com/GSA/dcat-us3-tools/commit/82d73d5a17b0b1aa18119be2d00c0ae6634e8a0b#diff-1b766490eabffd298e43e5293cd631617a368807b81bc8af2cdc1783906cd748

**Related to/addressing:** #19 