### PR TITLE
Remove the non-existent role definition reference.

### DIFF
--- a/jsonschema/definitions/Attribution.json
+++ b/jsonschema/definitions/Attribution.json
@@ -15,17 +15,7 @@
             "$id": "http://www.w3.org/ns/dcat#hadRole",
             "title": "role",
             "description": "The function of an entity or agent with respect to another entity or resource.",
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/Role",
-                    "description": "inline description of Role"
-                },
-                {
-                    "type": "string",
-                    "description": "reference iri of Role",
-                    "format": "iri"
-                }
-            ]
+            "type": "string"
         },
         "agent": {
             "$id": "http://www.w3.org/ns/prov#agent",

--- a/jsonschema/definitions/Relationship.json
+++ b/jsonschema/definitions/Relationship.json
@@ -15,17 +15,7 @@
             "$id": "http://www.w3.org/ns/dcat#hadRole",
             "title": "role",
             "description": "The function of an entity or agent with respect to another entity or resource.",
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/Role",
-                    "description": "inline description of Role"
-                },
-                {
-                    "type": "string",
-                    "description": "reference iri of Role",
-                    "format": "iri"
-                }
-            ]
+            "type": "string"
         },
         "relation": {
             "$id": "http://purl.org/dc/terms/relation",


### PR DESCRIPTION
Should resolve https://github.com/GSA/dcat-us/issues/20.

This makes the role a generic string. Examples (see https://doi-do.github.io/dcat-us/#attribution-example) utilizes a definition URL for resources that doesn't exist. Since this is not yet defined, leave as open-ended string until possible improvements to categories for this, and iterative improvement.