### PR TITLE
refactor 'expectedDataType' definition in Metric.json

### DIFF
--- a/jsonschema/definitions/Metric.json
+++ b/jsonschema/definitions/Metric.json
@@ -15,17 +15,7 @@
             "$id": "http://www.w3.org/ns/dqv#expectedDataType",
             "title": "expected datatype",
             "description": "Represents the expected data type for the metric's observed value (e.g., xsd:boolean, xsd:double etc...)",
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/anySimpleType",
-                    "description": "inline description of anySimpleType"
-                },
-                {
-                    "type": "string",
-                    "description": "reference iri of anySimpleType",
-                    "format": "iri"
-                }
-            ]
+            "type": "string"
         },
         "inDimension": {
             "$id": "http://www.w3.org/ns/dqv#inDimension",


### PR DESCRIPTION
I agree with James's assessment. Updated the `expectedDataType` definition to remove references to `anySimpleType` as it doesn't exist. The property description and examples in the documentation suggest a simple string should be sufficient.

**DOI DCAT-US 3.0 Documentation:** [Metric - expectedDataType](https://doi-do.github.io/dcat-us/#metric_expected_datatype)

**'xsd:anySimpleType' Documentation:** [XML built-in datatypes](https://www.w3.org/TR/xmlschema11-2/#built-in-datatypes), [XML anySimpleType](https://www.w3.org/TR/xmlschema11-2/#anySimpleType)

**Previous work:** https://github.com/GSA/dcat-us3-tools/commit/2a000494fe5ef70d8f15ae8e1a897ab9b219abd7#diff-53ebd1692a2d4cfa5e4a21fd688a1e6846b4a546e02c47991bc42af76839d0d8

**Should resolve:** #21 