### PR TITLE
refactor 'algorithm' definition in Checksum.json

### DIFF
--- a/jsonschema/definitions/Checksum.json
+++ b/jsonschema/definitions/Checksum.json
@@ -15,17 +15,7 @@
             "$id": "http://spdx.org/rdf/terms#algorithm",
             "title": "algorithm",
             "description": "The algorithm used to produce the subject Checksum.",
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/ChecksumAlgorithm",
-                    "description": "inline description of ChecksumAlgorithm"
-                },
-                {
-                    "type": "string",
-                    "description": "reference iri of ChecksumAlgorithm",
-                    "format": "iri"
-                }
-            ]
+            "type": "string"
         },
         "checksumValue": {
             "$id": "http://spdx.org/rdf/terms#checksumValue",


### PR DESCRIPTION
Updated the `algorithm` definition to remove references to `ChecksumAlgorithm` as it doesn't exist. Instead, it expects a string (simple solution). Will add a subsequent comment to PR that explains a potential alternative solution.

**DOI DCAT-US 3.0 Documentation:** [Checksum - algorithm](https://doi-do.github.io/dcat-us/#checksum-algorithm)

**Previous work:** https://github.com/GSA/dcat-us3-tools/commit/2a000494fe5ef70d8f15ae8e1a897ab9b219abd7#diff-53ebd1692a2d4cfa5e4a21fd688a1e6846b4a546e02c47991bc42af76839d0d8

**Should resolve:** #22 