### PR TITLE
add 'definition' property to Metric.json

### DIFF
--- a/jsonschema/definitions/Metric.json
+++ b/jsonschema/definitions/Metric.json
@@ -42,6 +42,19 @@
                     "format": "iri"
                 }
             ]
+        },
+        "definition": {
+            "$id": "https://www.w3.org/ns/dqv#definition",
+            "title": "definition",
+            "description": "Definition of the metric.",
+            "oneOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "string"
+                }
+            ]
         }
     },
     "required": [


### PR DESCRIPTION
Added a `definition` property to `Metric.json` as it is listed as a recommended property in the documentation but was missing from the jsonschema definition.

**I would appreciate a review of the $id field value**. I decided to match the approach/values used by the other two `Metric` properties but am a little confused about what URI/IRI is appropriate to use for the $id when there may be multiple options. For instance, the DOI documentation lists the URI as https://www.w3.org/TR/skos-reference/#definition; however, generally speaking, the jsonschema $id values don't seem to map to those. Additionally, as the `definition` property belongs to the SKOS vocabulary/namespace, other files like `Concept.json` include it and use an $id value of http://www.w3.org/2004/02/skos/core#definition.

**DOI DCAT-US 3.0 Documentation:** [Metric - definition](https://doi-do.github.io/dcat-us/#metric-definition)

**Should resolve:** #66 