### PR TITLE
Remove identifier as an array, make it singular.

### DIFF
--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -752,10 +752,7 @@
                     "type": "null"
                 },
                 {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 }
             ]
         },


### PR DESCRIPTION
This identifier field is mandatory (and is also mandatory in 1.1). This is critical for management systems tracking dataset uniqueness throughout publishing and harvest process. Without this singular identifier data publishing becomes much more muddled.

Should resolve https://github.com/GSA/dcat-us/issues/28.

If this is not the path forward, data.gov will need guidance on how to manage lists of identifiers (should every item in the array be unique? If an identifier changes, that would result in a delete and insert; if any item in the list changes, should it do the same?).