### PR TITLE
Dataset Spatial Reference forcing array list

### DIFF
--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -1026,6 +1026,15 @@
                     "type": "null"
                 },
                 {
+                    "$ref": "#/definitions/Location",
+                    "description": "inline description of Location"
+                },
+                {
+                    "type": "string",
+                    "description": "reference iri of Location",
+                    "format": "iri"
+                },
+                {
                     "type": "array",
                     "items": {
                         "oneOf": [


### PR DESCRIPTION
DCAT-US1.1 spatial is only a singular reference. Allow for singular reference (as well as the already defined list reference) here for backwards compatibility.

Managing the code for this is easy. There aren't a lot of use cases where the spatial field will be a list; the data in the field itself can already be multi-polygon.

This should resolve https://github.com/GSA/dcat-us/issues/30