### PR TITLE
refactor Catalog.json

### DIFF
--- a/jsonschema/definitions/Catalog.json
+++ b/jsonschema/definitions/Catalog.json
@@ -286,13 +286,9 @@
             "$id": "http://purl.org/dc/terms/description",
             "title": "description",
             "description": "Free-text description of the catalog (in the language indicated in the attribute).",
-            "oneOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string"
-                }
+            "type": [
+                "null", 
+                "string"
             ]
         },
         "descriptionMap": {
@@ -597,13 +593,9 @@
             "$id": "http://purl.org/dc/terms/title",
             "title": "title",
             "description": "The title of the catalog in the indicated language",
-            "oneOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string"
-                }
+            "type": [
+                "null", 
+                "string"
             ]
         },
         "titleMap": {


### PR DESCRIPTION
### Summary
In line with Neil and James's suggestions, updated the `Catalog` class to improve the backwards compatibility with DCAT-US 1.1, and to increase the usability of the `keyword` property and align with its use in the `Dataset` class.

Should resolve: #25, #74 

Relevant Documentation: [Catalog](https://doi-do.github.io/dcat-us/#properties-for-catalog)

### Changes to Catalog.json:
- `keyword` - changed from a string to an array of strings; matches `Dataset` and aligns with the cardinality in the documentation
- `description`, `publisher`, and `title` - removed from 'required' array; added option for a null value

### Discussion Topics
- `identifier` - Repeated point from my `Document` PR. Should it be changed from an array of strings to a string (e.g., from 0..n to 0..1)? We changed this for `Dataset` but it has the `otherIdentifier` property and `Catalog` does not.

### Documentation and jsonschema Desynchronization
I don't think these are particularly important to fix, and I also know we've discussed ditching the HTML documentation and generating the documentation from the jsonschema, but I thought I would list what I noticed here anyways:

- `keyword` - cardinality is 0..n in documentation, but 0..1 in jsonschema; **fixed as described in changes**
- `rights` - cardinality is 0..n in documentation, but 0..1 in jsonschema
- `rightsHolder` - cardinality is 0..n in property description and jsonschema, but 0..1 in class description