### PR TITLE
refactor Organization.json

### DIFF
--- a/jsonschema/definitions/Organization.json
+++ b/jsonschema/definitions/Organization.json
@@ -84,13 +84,9 @@
             "$id": "http://www.w3.org/2004/02/skos/core#prefLabel",
             "title": "preferred label",
             "description": "Preferred or legal name of the organization",
-            "oneOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string"
-                }
+            "type": [
+                "null", 
+                "string"
             ]
         },
         "prefLabelMap": {


### PR DESCRIPTION
### Summary
In line with James's suggestion, updated the `Organization` class to ease the backwards compatibility with DCAT-US 1.1

Should resolve: #31 

Relevant Documentation: [Organization](https://doi-do.github.io/dcat-us/#properties-for-organization)

### Changes to Organization.json:
- `prefLabel` - removed from 'required' array and added an option for a null value; eases backwards compatibility and aligns with the cardinality in the documentation

### Documentation and jsonschema Desynchronization
I don't think these are particularly important to fix, and I also know we've discussed ditching the HTML documentation and generating the documentation from the jsonschema, but I thought I would list what I noticed here anyways:
- `prefLabel` - cardinality is 0..1 in documentation, but 1 in jsonschema; **fixed through above changes**
- `altLabel` - cardinality is 0..n on documentation, jsonschema is 0..1; does the language map change the cardinality?
- `subOrganizationOf` - cardinality is 0..n in property description and jsonschema, but 0..1 in class description

