### PR TITLE
Update catalog for better backward compatibility, allow for multiple …

### DIFF
--- a/jsonschema/Catalog.json
+++ b/jsonschema/Catalog.json
@@ -83,11 +83,14 @@
         },
         "keyword": {
             "title": "keyword/tag",
-            "description": "A keyword or tag describing the resource",
+            "description": "A list of keywords or tags describing the resource",
             "type": [
                 "null",
-                "string"
-            ]
+                "array"
+            ],
+            "items": {
+                "type": "string"
+            }
         },
         "keywordMap": {
             "description": "Language map for property title. E.g. {'es': 'spanish words', 'fr': 'french words'}",
@@ -260,7 +263,10 @@
         "description": {
             "title": "description",
             "description": "Free-text description of the catalog (in the language indicated in the language property)",
-            "type": "string"
+            "type": [
+                "null",
+                "string"
+            ]
         },
         "descriptionMap": {
             "description": "Language map for description. E.g. {'es': 'spanish words', 'fr': 'french words'}",
@@ -408,6 +414,9 @@
             "description": "Agent responsible for making the catalog available",
             "oneOf": [
                 {
+                    "type": "null"
+                },
+                {
                     "$ref": "/dcat-us/3.0.0/definitions/agent",
                     "description": "inline description of the publisher"
                 },
@@ -539,7 +548,10 @@
         "title": {
             "title": "title",
             "description": "The title of the catalog in the indicated language",
-            "type": "string"
+            "type": [
+                "null",
+                "string"
+            ]
         },
         "titleMap": {
             "description": "Language map for property title. E.g. {'es': 'spanish words', 'fr': 'french words'}",
@@ -611,9 +623,6 @@
         }
     },
     "required": [
-        "dataset",
-        "description",
-        "publisher",
-        "title"
+        "dataset"
     ]
 }


### PR DESCRIPTION
Summary
In line with Neil and James's suggestions, updated the Catalog class to improve the backwards compatibility with DCAT-US 1.1, and to increase the usability of the keyword property and align with its use in the Dataset class.

This was already approved, but due to the large number of changes in https://github.com/GSA/dcat-us/pull/80, the previous version (https://github.com/GSA/dcat-us/pull/78) is not able to be merged. Recreated for now, and should be quickly approved.

Should resolve: https://github.com/GSA/dcat-us/issues/25, https://github.com/GSA/dcat-us/issues/74

Relevant Documentation: [Catalog](https://doi-do.github.io/dcat-us/#properties-for-catalog)

Changes to Catalog.json:
keyword - changed from a string to an array of strings; matches Dataset and aligns with the cardinality in the documentation
description, publisher, and title - removed from 'required' array; added option for a null value