### PR TITLE
Fix reference typo in Dataset.json

### DIFF
--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -355,7 +355,7 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "/dcat-us/3.0.0.0/definitions/concept",
+                                "$ref": "/dcat-us/3.0.0/definitions/concept",
                                 "description": "inline description of Concept"
                             },
                             {


### PR DESCRIPTION
An extra zero crept in during the big `$ref` cleanup. This fixes that.

I suggest that this PR doesn't need Tiger Team review because it makes the change that was originally intended and already has been approved.