### PR TITLE
resolve inconsistencies in prop desc between Data Service and Dataset

### DIFF
--- a/jsonschema/definitions/DataService.json
+++ b/jsonschema/definitions/DataService.json
@@ -157,7 +157,7 @@
     },
     "geographicBoundingBox": {
       "title": "geographic bounding box",
-      "description": "The spatial extent of domain of application of an data service and is standardized in WGS 84 Lat/Long coordinate system",
+      "description": "List of WGS84 Geographic Bounding Boxes for this Data Service",
       "anyOf": [
         {
           "type": "null"
@@ -182,7 +182,7 @@
     },
     "accessRights": {
       "title": "access rights",
-      "description": "Information regarding access or restrictions based on privacy, security, or other policies",
+      "description": "Information that indicates whether the Data Service is open data, has access restrictions or is public",
       "oneOf": [
         {
           "type": "null"
@@ -535,7 +535,7 @@
     },
     "qualifiedAttribution": {
       "title": "qualified attribution",
-      "description": "An Agent having some form of responsibility for the DataService",
+      "description": "List of agents having some form of responsibility for the Data Service",
       "anyOf": [
         {
           "type": "null"


### PR DESCRIPTION
**Should resolve:** #100 

A very simple change. Fixes inconsistencies between property descriptions in `Data Service` and `Dataset`. I felt that the descriptions in `Dataset` were both simpler and more accurate/closer to the intended use of the properties.

**Affected properties:**
- `geographicBoundingBox`, `accessRights`, and `qualifiedAttribution`
  - change descriptions in `Data Service` to match their counterparts in `Dataset`