### PR TITLE
Bug: Catalog Record, source field

### DIFF
--- a/jsonschema/definitions/CatalogRecord.json
+++ b/jsonschema/definitions/CatalogRecord.json
@@ -139,16 +139,16 @@
     "source": {
       "title": "source metadata",
       "description": "The original metadata that was used in creating metadata for the items in the catalog record, either a URL referencing the source metadata or a string of the source metadata itself",
-      "type": [ "null", "string" ]
+      "type": ["null", "string"]
     },
     "title": {
       "title": "title",
       "description": "A name given to the Catalog Record",
-      "type": [ "null", "string" ]
+      "type": ["null", "string"]
     },
     "titleMap": {
       "description": "Language map for property title. E.g. {'es': 'spanish words', 'fr': 'french words'}",
-      "type": [ "null", "object" ]
+      "type": ["null", "object"]
     },
     "primaryTopic": {
       "title": "primary topic",
@@ -156,5 +156,5 @@
       "type": "string"
     }
   },
-  "required": [ "modified", "primaryTopic" ]
+  "required": ["modified", "primaryTopic"]
 }


### PR DESCRIPTION
This should resolve https://github.com/GSA/dcat-us/issues/105.

Clearly this is a bug, the reference to `resource` doesn't exist.

From the description, this should clearly be a string and not referencing another dataset or other resource. It could be a URL to another version/copy of the metadata, or it could be an in-line version. To be permissive, just allow a string.