### PR TITLE
Use Kind instead of Person in Document

### DIFF
--- a/jsonschema/definitions/Document.json
+++ b/jsonschema/definitions/Document.json
@@ -48,8 +48,8 @@
       "items": {
         "anyOf": [
           {
-            "$ref": "/dcat-us/3.0.0/definitions/person",
-            "description": "inline description of Person"
+            "$ref": "/dcat-us/3.0.0/definitions/kind",
+            "description": "inline description of author"
           },
           {
             "type": "string",


### PR DESCRIPTION
In our other files we don't use the (non-existent) `Person` type.  For information about individuals we use the `Kind` class.

(IMO this is a bug fix and not a significant schema change and shouldn't need tiger team approval so the PR is targeted to main.)