### PR TITLE
redo changes from "standardize 'keyword' restictions" PR

### DIFF
--- a/jsonschema/Catalog.json
+++ b/jsonschema/Catalog.json
@@ -83,14 +83,15 @@
     },
     "keyword": {
       "title": "keyword/tag",
-      "description": "A list of keywords or tags describing the resource",
+      "description": "List of keywords or tags describing the Catalog",
       "type": ["null", "array"],
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "keywordMap": {
-      "description": "Language map for property title. E.g. {'es': 'spanish words', 'fr': 'french words'}",
+      "description": "Language map for keyword. E.g. {'es': 'spanish words', 'fr': 'french words'}",
       "type": ["null", "object"]
     },
     "record": {

--- a/jsonschema/definitions/DataService.json
+++ b/jsonschema/definitions/DataService.json
@@ -68,10 +68,11 @@
     },
     "keyword": {
       "title": "keyword/tag",
-      "description": "A list of keywords or tags describing the Data Service",
+      "description": "List of keywords or tags describing the Data Service",
       "type": ["null", "array"],
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "keywordMap": {

--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -242,18 +242,11 @@
     "keyword": {
       "title": "keyword/tag",
       "description": "List of keywords or tags describing the Dataset",
-      "anyOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
-        }
-      ]
+      "type": ["null", "array"],
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     },
     "keywordMap": {
       "description": "Language map for keyword. E.g. {'es': 'spanish words', 'fr': 'french words'}",


### PR DESCRIPTION
The changes made in PR #102 seem to have been lost. This PR recreates the changes and resolves #98 

**Changes:**
- add "minLength": 1 restriction to Catalog and Data Service
- flatten "anyOf" in Dataset to match the structure/format in Catalog and Data Service
- fix typos in property descriptions to align them across the classes