### PR TITLE
Remove Links from every property

### DIFF
--- a/jsonschema/Catalog.json
+++ b/jsonschema/Catalog.json
@@ -18,19 +18,7 @@
       "description": "List of related catalogs whose contents are of interest in the context of this catalog",
       "type": ["null", "array"],
       "items": {
-        "title": "Catalog or a link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/catalog",
-            "description": "inline description of Catalog"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Catalog",
-            "format": "iri"
-          }
-        ]
+        "$ref": "#"
       }
     },
     "contactPoint": {
@@ -38,19 +26,7 @@
       "description": "Contact information that can be used for sending comments about the Catalog",
       "type": ["null", "array"],
       "items": {
-        "title": "Contact point or a link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/kind",
-            "description": "inline value for contact point"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of contact point",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/kind"
       }
     },
     "dataset": {
@@ -58,18 +34,7 @@
       "description": "List of Datasets that are part of the Catalog",
       "type": "array",
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/dataset",
-            "description": "inline description of Dataset"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Dataset",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/dataset"
       }
     },
     "keyword": {
@@ -90,18 +55,7 @@
       "description": "A record describing a single resource (e.g., a dataset, a data service) that is part of the catalog",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/catalogrecord",
-            "description": "inline description of the record"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of the record",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/catalogrecord"
       }
     },
     "service": {
@@ -109,18 +63,7 @@
       "description": "List of data services that are listed in the Catalog",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/dataservice",
-            "description": "inline description of the service"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of the service",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/dataservice"
       }
     },
     "theme": {
@@ -128,18 +71,7 @@
       "description": "A list of categories for the Catalog. A Catalog may be associated with multiple themes",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/concept",
-            "description": "inline description of the theme"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of the theme",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/concept"
       }
     },
     "themeTaxonomy": {
@@ -147,18 +79,7 @@
       "description": "A knowledge organization system (KOS) used to classify the resources documented in the catalog (e.g., datasets and services)",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/conceptscheme",
-            "description": "inline description of ConceptScheme"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of ConceptScheme",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/conceptscheme"
       }
     },
     "accessRights": {
@@ -172,12 +93,6 @@
         {
           "type": "string",
           "description": "Text description of the access rights"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the access rights",
-          "format": "iri"
         }
       ]
     },
@@ -190,14 +105,7 @@
           "title": "Null allowed when not required"
         },
         {
-          "$ref": "/dcat-us/3.0.0/definitions/standard",
-          "description": "inline description of Standard"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Standard",
-          "format": "iri"
+          "$ref": "/dcat-us/3.0.0/definitions/standard"
         }
       ]
     },
@@ -206,18 +114,7 @@
       "description": "The entity responsible for creating the resource",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/agent",
-            "description": "inline description of creator"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of creator",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/agent"
       }
     },
     "description": {
@@ -234,18 +131,7 @@
       "description": "A list of related catalogs that are part of the described catalog",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "#",
-            "description": "inline description of the related catalog"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of the related catalog",
-            "format": "iri"
-          }
-        ]
+        "$ref": "#"
       }
     },
     "identifier": {
@@ -259,12 +145,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/identifier",
           "description": "inline description of Identifier"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Identifier",
-          "format": "iri"
         }
       ]
     },
@@ -273,18 +153,7 @@
       "description": "A list of identifiers for the Catalog besides the main identifier, e.g. the URI or other unique identifiers",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/identifier",
-            "description": "inline description of Identifier"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Identifier",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/identifier"
       }
     },
     "issued": {
@@ -355,12 +224,6 @@
         {
           "type": "string",
           "description": "Full text of the license"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the license",
-          "format": "iri"
         }
       ]
     },
@@ -408,12 +271,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/agent",
           "description": "inline description of the publisher"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the publisher",
-          "format": "iri"
         }
       ]
     },
@@ -422,19 +279,8 @@
       "description": "A list of statements concerning all rights for the Catalog that may not be addressed by license or accessRights, such as copyright statements, statements about the intellectual property rights (IPR), or information regarding access or restrictions based on privacy, security, or other policies",
       "type": ["null", "array"],
       "items": {
-        "title": "Rights statement text or link",
-        "anyOf": [
-          {
-            "type": "string",
-            "description": "Full text of a statement of rights"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of a statement of rights",
-            "format": "iri"
-          }
-        ]
+        "type": "string",
+        "description": "Full text of a statement of rights"
       }
     },
     "rightsHolder": {
@@ -442,18 +288,7 @@
       "description": "List of organizations holding rights on the catalog",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/organization",
-            "description": "inline description of rights holder"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of rights holder",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/organization"
       }
     },
     "spatial": {
@@ -461,18 +296,7 @@
       "description": "The geographical area covered by the catalog",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/location",
-            "description": "inline description of geographical coverage"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of geographical coverage",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/location"
       }
     },
     "subject": {
@@ -480,18 +304,7 @@
       "description": "List of subjects of the catalog",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/concept",
-            "description": "inline description of the subject"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of the subject",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/concept"
       }
     },
     "temporal": {
@@ -499,18 +312,7 @@
       "description": "List of temporal periods that the Catalog covers",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/periodoftime",
-            "description": "inline description of the temporal coverage"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of the temporal coverage",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/periodoftime"
       }
     },
     "title": {
@@ -527,18 +329,7 @@
       "description": "List of categories for the Catalog",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/concept",
-            "description": "inline description of Concept"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Concept",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/concept"
       }
     },
     "homepage": {
@@ -552,12 +343,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/document",
           "description": "inline description of the home page"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the home page",
-          "format": "iri"
         }
       ]
     },
@@ -566,18 +351,7 @@
       "description": "A list of agents having some form of responsibility for the catalog",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/attribution",
-            "description": "inline description of Attribution"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Attribution",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/attribution"
       }
     }
   },

--- a/jsonschema/definitions/AccessRestriction.json
+++ b/jsonschema/definitions/AccessRestriction.json
@@ -25,18 +25,7 @@
     "restrictionStatus": {
       "title": "restriction status",
       "description": "The indication of whether or not there are access restrictions on the item",
-      "anyOf": [
-        {
-          "$ref": "/dcat-us/3.0.0/definitions/concept",
-          "description": "inline description of restriction status"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of restriction status",
-          "format": "iri"
-        }
-      ]
+      "$ref": "/dcat-us/3.0.0/definitions/concept"
     },
     "specificRestriction": {
       "title": "specific restriction",
@@ -49,12 +38,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/concept",
           "description": "inline description of the specific restriction"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the specific restriction",
-          "format": "iri"
         }
       ]
     }

--- a/jsonschema/definitions/Activity.json
+++ b/jsonschema/definitions/Activity.json
@@ -18,18 +18,7 @@
       "description": "List of categories for the Activity",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/concept",
-            "description": "inline description of Concept"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Concept",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/concept"
       }
     },
     "label": {

--- a/jsonschema/definitions/Agent.json
+++ b/jsonschema/definitions/Agent.json
@@ -18,18 +18,7 @@
       "description": "The type of the agent that makes the item available",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/concept",
-            "description": "inline description of Concept"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Concept",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/concept"
       }
     },
     "name": {

--- a/jsonschema/definitions/Attribution.json
+++ b/jsonschema/definitions/Attribution.json
@@ -21,18 +21,7 @@
     "agent": {
       "title": "agent",
       "description": "The agent that plays a role in the resource",
-      "anyOf": [
-        {
-          "$ref": "/dcat-us/3.0.0/definitions/agent",
-          "description": "inline description of Agent"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Agent",
-          "format": "iri"
-        }
-      ]
+      "$ref": "/dcat-us/3.0.0/definitions/agent"
     }
   },
   "required": ["hadRole", "agent"]

--- a/jsonschema/definitions/CatalogRecord.json
+++ b/jsonschema/definitions/CatalogRecord.json
@@ -24,12 +24,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/concept",
           "description": "inline description of status"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of status",
-          "format": "iri"
         }
       ]
     },
@@ -44,12 +38,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/standard",
           "description": "inline description of application profile"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of application profile",
-          "format": "iri"
         }
       ]
     },

--- a/jsonschema/definitions/Concept.json
+++ b/jsonschema/definitions/Concept.json
@@ -41,17 +41,7 @@
         "inScheme": {
           "title": "in scheme",
           "description": "Concept scheme defining this concept",
-          "anyOf": [
-            {
-              "$ref": "/dcat-us/3.0.0/definitions/conceptscheme",
-              "description": "inline description of ConceptScheme"
-            },
-            {
-              "type": "string",
-              "description": "reference iri of ConceptScheme",
-              "format": "iri"
-            }
-          ]
+          "$ref": "/dcat-us/3.0.0/definitions/conceptscheme"
         },
         "notation": {
           "title": "notation",

--- a/jsonschema/definitions/DataService.json
+++ b/jsonschema/definitions/DataService.json
@@ -18,19 +18,7 @@
       "description": "Contact information that can be used for sending comments about the Data Service",
       "type": "array",
       "items": {
-        "title": "Kind object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/kind",
-            "description": "inline description of Kind"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Kind",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/kind"
       }
     },
     "endpointDescription": {
@@ -38,18 +26,7 @@
       "description": "A list of descriptions of the services available via the end-points, including their operations, parameters etc",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "type": "string",
-            "description": "An in-line description of the endpoint description"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of the endpoint description",
-            "format": "iri"
-          }
-        ]
+        "type": "string"
       }
     },
     "endpointURL": {
@@ -82,19 +59,7 @@
       "description": "List of datasets that are served by this data service",
       "type": ["null", "array"],
       "items": {
-        "title": "Dataset object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/dataset",
-            "description": "inline description of Dataset"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Dataset",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/dataset"
       }
     },
     "spatialResolutionInMeters": {
@@ -112,19 +77,7 @@
       "description": "A list of themes of the Data Service. A Data Service may be associated with multiple themes",
       "type": ["null", "array"],
       "items": {
-        "title": "Theme or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/concept",
-            "description": "inline description of Concept"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Concept",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/concept"
       }
     },
     "accessRights": {
@@ -137,12 +90,6 @@
         {
           "type": "string",
           "description": "Text description of the access rights"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the access rights",
-          "format": "iri"
         }
       ]
     },
@@ -151,19 +98,7 @@
       "description": "List of general standards or specifications that the Data Service endpoints implement",
       "type": ["null", "array"],
       "items": {
-        "title": "Standard object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/standard",
-            "description": "inline description of Standard"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Standard",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/standard"
       }
     },
     "created": {
@@ -203,19 +138,7 @@
       "description": "List of agents primarily responsible for producing the Data Service",
       "type": ["null", "array"],
       "items": {
-        "title": "Agent object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/agent",
-            "description": "inline description of Agent"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Agent",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/agent"
       }
     },
     "description": {
@@ -237,12 +160,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/identifier",
           "description": "inline description of Identifier"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Identifier",
-          "format": "iri"
         }
       ]
     },
@@ -251,18 +168,7 @@
       "description": "A list of identifiers for the Data Service besides the main identifier, e.g. the URI or other unique identifiers in the context of the Catalog",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/identifier",
-            "description": "inline description of Identifier"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Identifier",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/identifier"
       }
     },
     "language": {
@@ -300,12 +206,6 @@
         {
           "type": "string",
           "description": "Full text of the license"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the license",
-          "format": "iri"
         }
       ]
     },
@@ -345,37 +245,14 @@
     "publisher": {
       "title": "publisher",
       "description": "An entity (organization) responsible for making the Data Service available",
-      "anyOf": [
-        {
-          "$ref": "/dcat-us/3.0.0/definitions/agent",
-          "description": "inline description of Agent"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Agent",
-          "format": "iri"
-        }
-      ]
+      "$ref": "/dcat-us/3.0.0/definitions/agent"
     },
     "rights": {
       "title": "rights",
       "description": "A list of statements concerning all rights for the Data Service that may not be addressed by license or accessRights, such as copyright statements, statements about the intellectual property rights (IPR), or information regarding access or restrictions based on privacy, security, or other policies",
       "type": ["null", "array"],
       "items": {
-        "title": "RightsStatement object or link",
-        "anyOf": [
-          {
-            "type": "string",
-            "description": "Full text of a statement of rights"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of a statement of rights",
-            "format": "iri"
-          }
-        ]
+        "type": "string"
       }
     },
     "rightsHolder": {
@@ -383,19 +260,7 @@
       "description": "A list of Agents (organizations) holding rights on the Data Service",
       "type": ["null", "array"],
       "items": {
-        "title": "Organization object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/organization",
-            "description": "inline description of Organization"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Organization",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/organization"
       }
     },
     "spatial": {
@@ -403,19 +268,7 @@
       "description": "A geographic region that is covered by the Data Service",
       "type": ["null", "array"],
       "items": {
-        "title": "Location object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/location",
-            "description": "inline description of Location"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Location",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/location"
       }
     },
     "temporal": {
@@ -423,19 +276,7 @@
       "description": "A list of temporal periods that the DataService covers",
       "type": ["null", "array"],
       "items": {
-        "title": "PeriodOfTime object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/periodoftime",
-            "description": "inline description of PeriodOfTime"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of PeriodOfTime",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/periodoftime"
       }
     },
     "title": {
@@ -452,19 +293,7 @@
       "description": "List of categories for the Data Service",
       "type": ["null", "array"],
       "items": {
-        "title": "Category or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/concept",
-            "description": "inline description of Concept"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Concept",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/concept"
       }
     },
     "hasQualityMeasurement": {
@@ -472,19 +301,7 @@
       "description": "Refers to the performed quality measurements",
       "type": ["null", "array"],
       "items": {
-        "title": "QualityMeasurement object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/qualitymeasurement",
-            "description": "inline description of QualityMeasurement"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of QualityMeasurement",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/qualitymeasurement"
       }
     },
     "qualifiedAttribution": {
@@ -492,19 +309,7 @@
       "description": "List of agents having some form of responsibility for the Data Service",
       "type": ["null", "array"],
       "items": {
-        "title": "Attribution object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/attribution",
-            "description": "inline description of Attribution"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Attribution",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/attribution"
       }
     },
     "wasUsedBy": {
@@ -512,19 +317,7 @@
       "description": "List of activities that used the Data Service",
       "type": ["null", "array"],
       "items": {
-        "title": "Activity object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/activity",
-            "description": "inline description of Activity"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Activity",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/activity"
       }
     }
   },

--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -18,18 +18,7 @@
       "description": "A list of identifiers for the Dataset besides the main identifier, e.g. the URI or other unique identifiers in the context of the Catalog",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/identifier",
-            "description": "inline description of Identifier"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Identifier",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/identifier"
       }
     },
     "sample": {
@@ -37,19 +26,7 @@
       "description": "List of links to samples of a Dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Distribution object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/distribution",
-            "description": "inline description of Distribution"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Distribution",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/distribution"
       }
     },
     "status": {
@@ -63,12 +40,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/concept",
           "description": "inline description of Concept"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Concept",
-          "format": "iri"
         }
       ]
     },
@@ -83,12 +54,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/dataset",
           "description": "inline description of the supported schema"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the supported schema",
-          "format": "iri"
         }
       ]
     },
@@ -106,28 +71,10 @@
           "description": "inline description of Kind"
         },
         {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Kind",
-          "format": "iri"
-        },
-        {
           "type": "array",
           "title": "List of contacts",
           "items": {
-            "title": "Kind object or link",
-            "anyOf": [
-              {
-                "$ref": "/dcat-us/3.0.0/definitions/kind",
-                "description": "inline description of Kind"
-              },
-              {
-                "type": "string",
-                "title": "Link",
-                "description": "reference iri of Kind",
-                "format": "iri"
-              }
-            ]
+            "$ref": "/dcat-us/3.0.0/definitions/kind"
           }
         }
       ]
@@ -137,19 +84,7 @@
       "description": "List of available distributions for the Dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Distribution object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/distribution",
-            "description": "inline description of Distribution"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Distribution",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/distribution"
       }
     },
     "first": {
@@ -163,12 +98,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/dataset",
           "description": "inline description of Dataset"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Dataset",
-          "format": "iri"
         }
       ]
     },
@@ -183,12 +112,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/dataset",
           "description": "inline description of Dataset"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Dataset",
-          "format": "iri"
         }
       ]
     },
@@ -197,19 +120,7 @@
       "description": "List of related Datasets that are a version, edition, or adaptation of the described Dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Dataset object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/dataset",
-            "description": "inline description of Dataset"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Dataset",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/dataset"
       }
     },
     "inSeries": {
@@ -217,19 +128,7 @@
       "description": "List of Dataset Series this dataset belongs to",
       "type": ["null", "array"],
       "items": {
-        "title": "DatasetSeries object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/datasetseries",
-            "description": "inline description of DatasetSeries"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of DatasetSeries",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/datasetseries"
       }
     },
     "keyword": {
@@ -257,12 +156,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/document",
           "description": "inline description of Document"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Document",
-          "format": "iri"
         }
       ]
     },
@@ -277,12 +170,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/dataset",
           "description": "inline description of Dataset"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Dataset",
-          "format": "iri"
         }
       ]
     },
@@ -291,19 +178,7 @@
       "description": "Qualified relationship with role of the dataset with another resource",
       "type": ["null", "array"],
       "items": {
-        "title": "Relationship object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/relationship",
-            "description": "inline description of Relationship"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Relationship",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/relationship"
       }
     },
     "spatialResolutionInMeters": {
@@ -321,19 +196,7 @@
       "description": "List of themes of the dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Theme or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/concept",
-            "description": "inline description of Concept"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Concept",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/concept"
       }
     },
     "version": {
@@ -352,12 +215,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/distribution",
           "description": "inline description of Distribution"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Distribution",
-          "format": "iri"
         }
       ]
     },
@@ -372,12 +229,6 @@
         {
           "type": "string",
           "description": "Full text of the liability statement"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the liability statement",
-          "format": "iri"
         }
       ]
     },
@@ -386,19 +237,7 @@
       "description": "Distribution to \"original\" metadata document",
       "type": ["null", "array"],
       "items": {
-        "title": "Distribution object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/distribution",
-            "description": "inline description of Distribution"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Distribution",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/distribution"
       }
     },
     "purpose": {
@@ -421,12 +260,6 @@
         {
           "type": "string",
           "description": "Text description of the access rights"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the access rights",
-          "format": "iri"
         }
       ]
     },
@@ -491,19 +324,7 @@
       "description": "List of standards to which the described Dataset conforms",
       "type": ["null", "array"],
       "items": {
-        "title": "Standard object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/standard",
-            "description": "inline description of Standard"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Standard",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/standard"
       }
     },
     "contributor": {
@@ -511,19 +332,7 @@
       "description": "List of agents contributing to the Dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Agent object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/agent",
-            "description": "inline description of Agent"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Agent",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/agent"
       }
     },
     "created": {
@@ -570,12 +379,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/agent",
           "description": "inline description of Agent"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Agent",
-          "format": "iri"
         }
       ]
     },
@@ -593,19 +396,7 @@
       "description": "List of related datasets that are part of the described dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Dataset object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/dataset",
-            "description": "inline description of Dataset"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Dataset",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/dataset"
       }
     },
     "identifier": {
@@ -619,12 +410,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/identifier",
           "description": "inline description of Identifier"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Identifier",
-          "format": "iri"
         }
       ]
     },
@@ -734,36 +519,14 @@
       "description": "List of statements about the lineage of a Dataset, including any changes in its ownership or custody since its creation that may be significant for its authenticity, integrity, or interpretation",
       "type": ["null", "array"],
       "items": {
-        "title": "Provenance statement text or link",
-        "anyOf": [
-          {
-            "type": "string",
-            "description": "Full text of the provenance statement"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of the provenance statement",
-            "format": "iri"
-          }
-        ]
+        "type": "string",
+        "description": "Full text of the provenance statement"
       }
     },
     "publisher": {
       "title": "publisher",
       "description": "An organization responsible for making the Dataset available",
-      "anyOf": [
-        {
-          "$ref": "/dcat-us/3.0.0/definitions/organization",
-          "description": "inline description of Organization"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Organization",
-          "format": "iri"
-        }
-      ]
+      "$ref": "/dcat-us/3.0.0/definitions/organization"
     },
     "relation": {
       "title": "related resource",
@@ -781,19 +544,7 @@
       "description": "List of Datasets replaced by this Dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Dataset object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/dataset",
-            "description": "inline description of Dataset"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Dataset",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/dataset"
       }
     },
     "rights": {
@@ -801,19 +552,8 @@
       "description": "A list of statements concerning all rights for the Dataset that may not be addressed by license or accessRights, such as copyright statements, statements about the intellectual property rights (IPR), or information regarding access or restrictions based on privacy, security, or other policies",
       "type": ["null", "array"],
       "items": {
-        "title": "Statement of rights or link",
-        "anyOf": [
-          {
-            "type": "string",
-            "description": "Full text of a statement of rights"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of a statement of rights",
-            "format": "iri"
-          }
-        ]
+        "type": "string",
+        "description": "Full text of a statement of rights"
       }
     },
     "rightsHolder": {
@@ -821,19 +561,7 @@
       "description": "List of agents (organizations) holding rights on the Dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Organization or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/organization",
-            "description": "inline description of Organization"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Organization",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/organization"
       }
     },
     "source": {
@@ -841,19 +569,7 @@
       "description": "List of related Datasets from which the described Dataset is derived",
       "type": ["null", "array"],
       "items": {
-        "title": "Dataset object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/dataset",
-            "description": "inline description of Dataset"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Dataset",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/dataset"
       }
     },
     "spatial": {
@@ -869,28 +585,10 @@
           "description": "inline description of Location"
         },
         {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Location",
-          "format": "iri"
-        },
-        {
           "type": "array",
           "title": "List of geographic regions",
           "items": {
-            "title": "Location or link",
-            "anyOf": [
-              {
-                "$ref": "/dcat-us/3.0.0/definitions/location",
-                "description": "inline description of Location"
-              },
-              {
-                "type": "string",
-                "title": "Link",
-                "description": "reference iri of Location",
-                "format": "iri"
-              }
-            ]
+            "$ref": "/dcat-us/3.0.0/definitions/location"
           }
         }
       ]
@@ -900,19 +598,7 @@
       "description": "List of primary subjects of the dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Subject or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/concept",
-            "description": "inline description of Concept"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Concept",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/concept"
       }
     },
     "temporal": {
@@ -920,19 +606,7 @@
       "description": "List of temporal periods that the dataset covers",
       "type": ["null", "array"],
       "items": {
-        "title": "PeriodOfTime object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/periodoftime",
-            "description": "inline description of PeriodOfTime"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of PeriodOfTime",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/periodoftime"
       }
     },
     "title": {
@@ -949,19 +623,7 @@
       "description": "List of categories for the Dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Category or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/concept",
-            "description": "inline description of Concept"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Concept",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/concept"
       }
     },
     "hasQualityMeasurement": {
@@ -969,18 +631,7 @@
       "description": "List of quality measurements for the dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "QualityMeasurement or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/qualitymeasurement",
-            "description": "inline description of QualityMeasurement"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of QualityMeasurement"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/qualitymeasurement"
       }
     },
     "page": {
@@ -988,19 +639,7 @@
       "description": "List of pages or documents about this dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Document object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/document",
-            "description": "inline description of Document"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Document",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/document"
       }
     },
     "qualifiedAttribution": {
@@ -1008,19 +647,7 @@
       "description": "List of agents having some form of responsibility for the dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Attribution object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/attribution",
-            "description": "inline description of Attribution"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Attribution",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/attribution"
       }
     },
     "wasAttributedTo": {
@@ -1028,19 +655,7 @@
       "description": "List of agents attributed to this dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Agent object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/agent",
-            "description": "inline description of Agent"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Agent",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/agent"
       }
     },
     "wasGeneratedBy": {
@@ -1048,19 +663,7 @@
       "description": "List of activities that generated, or provide the business context for the creation of the dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Activity object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/activity",
-            "description": "inline description of Activity"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Activity",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/activity"
       }
     },
     "wasUsedBy": {
@@ -1068,19 +671,7 @@
       "description": "List of activities that used the Dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "Activity object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/activity",
-            "description": "inline description of Activity"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Activity",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/activity"
       }
     },
     "image": {

--- a/jsonschema/definitions/DatasetSeries.json
+++ b/jsonschema/definitions/DatasetSeries.json
@@ -18,19 +18,7 @@
       "description": "List of contacts that can be used for sending comments about the Dataset Series",
       "type": ["null", "array"],
       "items": {
-        "title": "Kind object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/kind",
-            "description": "inline description of the contact"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of the contact",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/kind"
       }
     },
     "first": {
@@ -44,12 +32,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/dataset",
           "description": "inline description of the first dataset"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the first dataset",
-          "format": "iri"
         }
       ]
     },
@@ -64,12 +46,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/dataset",
           "description": "inline description of the last dataset"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the last dataset",
-          "format": "iri"
         }
       ]
     },
@@ -78,19 +54,7 @@
       "description": "List of members of the Dataset Series",
       "type": ["null", "array"],
       "items": {
-        "title": "Dataset object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/dataset",
-            "description": "inline description of the member dataset"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of the member dataset",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/dataset"
       }
     },
     "accrualPeriodicity": {
@@ -235,12 +199,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/agent",
           "description": "inline description of publisher"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of publisher",
-          "format": "iri"
         }
       ]
     },
@@ -249,19 +207,7 @@
       "description": "A geographic region that is covered by the Dataset Series",
       "type": ["null", "array"],
       "items": {
-        "title": "Location object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/location",
-            "description": "inline description of Location"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Location",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/location"
       }
     },
     "temporal": {
@@ -269,19 +215,7 @@
       "description": "A list of temporal periods that the Dataset Series covers",
       "type": ["null", "array"],
       "items": {
-        "title": "PeriodOfTime object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/periodoftime",
-            "description": "inline description of PeriodOfTime"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of PeriodOfTime",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/periodoftime"
       }
     },
     "title": {

--- a/jsonschema/definitions/Distribution.json
+++ b/jsonschema/definitions/Distribution.json
@@ -24,12 +24,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/concept",
           "description": "inline description of Concept"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Concept",
-          "format": "iri"
         }
       ]
     },
@@ -44,12 +38,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/concept",
           "description": "inline description of Concept"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Concept",
-          "format": "iri"
         }
       ]
     },
@@ -76,19 +64,7 @@
       "description": "A data service that gives access to the distribution of the dataset",
       "type": ["null", "array"],
       "items": {
-        "title": "DataService object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/dataservice",
-            "description": "inline description of DataService"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of DataService",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/dataservice"
       }
     },
     "accessURL": {
@@ -164,12 +140,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/concept",
           "description": "inline description of Concept"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Concept",
-          "format": "iri"
         }
       ]
     },
@@ -178,19 +148,7 @@
       "description": "List of access restrictions related to the distribution",
       "type": ["null", "array"],
       "items": {
-        "title": "AccessRestriction object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/accessrestriction",
-            "description": "inline description of AccessRestriction"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of AccessRestriction",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/accessrestriction"
       }
     },
     "cuiRestriction": {
@@ -204,12 +162,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/cuirestriction",
           "description": "inline description of CUIRestriction"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of CUIRestriction",
-          "format": "iri"
         }
       ]
     },
@@ -224,12 +176,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/distribution",
           "description": "inline description of the data dictionary"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the data dictionary",
-          "format": "iri"
         }
       ]
     },
@@ -238,19 +184,7 @@
       "description": "Use restriction related to the distribution",
       "type": ["null", "array"],
       "items": {
-        "title": "UseRestriction object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/userestriction",
-            "description": "inline description of UseRestriction"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of UseRestriction",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/userestriction"
       }
     },
     "accessRights": {
@@ -264,12 +198,6 @@
         {
           "type": "string",
           "description": "Text description of the access rights"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the access rights",
-          "format": "iri"
         }
       ]
     },
@@ -278,19 +206,7 @@
       "description": "List of established schemas or reference systems to which the described Distribution conforms",
       "type": ["null", "array"],
       "items": {
-        "title": "Standard object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/standard",
-            "description": "inline description of Standard"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Standard",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/standard"
       }
     },
     "description": {
@@ -318,12 +234,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/identifier",
           "description": "inline description of Identifier"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Identifier",
-          "format": "iri"
         }
       ]
     },
@@ -332,19 +242,7 @@
       "description": "A list of identifiers for the Distribution besides the main identifier, e.g. the URI or other unique identifiers in the context of the Catalog",
       "type": ["null", "array"],
       "items": {
-        "title": "Identifier object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/identifier",
-            "description": "inline description of Identifier"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Identifier",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/identifier"
       }
     },
     "issued": {
@@ -415,12 +313,6 @@
         {
           "type": "string",
           "description": "Full text of the license"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the license",
-          "format": "iri"
         }
       ]
     },
@@ -462,18 +354,8 @@
       "description": "A list of statements concerning all rights for the Distribution that may not be addressed by license or accessRights, such as copyright statements, statements about the intellectual property rights (IPR), or information regarding access or restrictions based on privacy, security, or other policies",
       "type": ["null", "array"],
       "items": {
-        "title": "Rights statement text or link",
-        "anyOf": [
-          {
-            "type": "string",
-            "description": "Full text of a statement of rights"
-          },
-          {
-            "type": "string",
-            "description": "reference iri of a statement of rights",
-            "format": "iri"
-          }
-        ]
+        "type": "string",
+        "description": "Full text of a statement of rights"
       }
     },
     "title": {
@@ -490,19 +372,7 @@
       "description": "A list of quality measurements for the distribution",
       "type": ["null", "array"],
       "items": {
-        "title": "QualityMeasurement object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/qualitymeasurement",
-            "description": "inline description of QualityMeasurement"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of QualityMeasurement",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/qualitymeasurement"
       }
     },
     "page": {
@@ -510,19 +380,7 @@
       "description": "A page or document about this Distribution",
       "type": ["null", "array"],
       "items": {
-        "title": "Document object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/document",
-            "description": "inline description of Document"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Document",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/document"
       }
     },
     "image": {
@@ -552,12 +410,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/checksum",
           "description": "inline description of Checksum"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Checksum",
-          "format": "iri"
         }
       ]
     }

--- a/jsonschema/definitions/Document.json
+++ b/jsonschema/definitions/Document.json
@@ -50,19 +50,7 @@
       "description": "The individual(s) responsible for creating the Document",
       "type": ["null", "array"],
       "items": {
-        "title": "Kind or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/kind",
-            "description": "inline description of author"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of author",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/kind"
       }
     },
     "mediaType": {
@@ -89,19 +77,7 @@
       "description": "List of standards that the Document conforms to",
       "type": ["null", "array"],
       "items": {
-        "title": "Standard object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/standard",
-            "description": "inline description of Standard"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Standard",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/standard"
       }
     },
     "corporateCreator": {
@@ -109,19 +85,7 @@
       "description": "The corporate organization(s) responsible for creating the Document",
       "type": ["null", "array"],
       "items": {
-        "title": "Organization or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/organization",
-            "description": "inline description of corporate author"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of corporate author",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/organization"
       }
     },
     "description": {
@@ -144,12 +108,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/identifier",
           "description": "inline description of Identifier"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Identifier",
-          "format": "iri"
         }
       ]
     },
@@ -158,19 +116,7 @@
       "description": "A list of identifiers for the Document besides the main identifier, e.g. the URI or other unique identifiers in the context of the Catalog",
       "type": ["null", "array"],
       "items": {
-        "title": "Identifier object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/identifier",
-            "description": "inline description of Identifier"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Identifier",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/identifier"
       }
     },
     "issued": {
@@ -210,19 +156,7 @@
       "description": "The organization(s) that published the Document",
       "type": ["null", "array"],
       "items": {
-        "title": "Organization object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/organization",
-            "description": "inline description of publisher"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of publisher",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/organization"
       }
     },
     "title": {
@@ -239,19 +173,7 @@
       "description": "List of categories/genres for the Document",
       "type": ["null", "array"],
       "items": {
-        "title": "Category or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/concept",
-            "description": "inline description of Concept"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Concept",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/concept"
       }
     }
   },

--- a/jsonschema/definitions/Identifier.json
+++ b/jsonschema/definitions/Identifier.json
@@ -36,12 +36,6 @@
             {
               "$ref": "/dcat-us/3.0.0/definitions/organization",
               "description": "inline description of the creator"
-            },
-            {
-              "type": "string",
-              "title": "Link",
-              "description": "reference iri of the creator",
-              "format": "iri"
             }
           ]
         },

--- a/jsonschema/definitions/Kind.json
+++ b/jsonschema/definitions/Kind.json
@@ -18,19 +18,7 @@
       "description": "The address of the contact",
       "type": ["null", "array"],
       "items": {
-        "title": "Address object or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/address",
-            "description": "inline address information"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Address",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/address"
       }
     },
     "hasEmail": {

--- a/jsonschema/definitions/Location.json
+++ b/jsonschema/definitions/Location.json
@@ -82,11 +82,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/identifier",
           "description": "inline description of Identifier"
-        },
-        {
-          "type": "string",
-          "description": "reference iri of Identifier",
-          "format": "iri"
         }
       ]
     },
@@ -95,17 +90,7 @@
       "description": "A list of geographic identifiers for the Location besides the main identifier, e.g. the URI or other unique identifiers in the context of the relevant gazetteer",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/identifier",
-            "description": "inline description of Identifier"
-          },
-          {
-            "type": "string",
-            "description": "reference iri of Identifier",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/identifier"
       }
     },
     "geometry": {
@@ -136,11 +121,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/conceptscheme",
           "description": "inline description of the gazetteer"
-        },
-        {
-          "type": "string",
-          "description": "reference iri of the gazetteer",
-          "format": "iri"
         }
       ]
     },

--- a/jsonschema/definitions/Organization.json
+++ b/jsonschema/definitions/Organization.json
@@ -23,19 +23,7 @@
       "description": "Represents hierarchical containment of Organizations or OrganizationalUnits; indicates an Organization which contains this Organization",
       "type": ["null", "array"],
       "items": {
-        "title": "Organization object or link",
-        "anyOf": [
-          {
-            "$ref": "#",
-            "description": "inline description of Organization"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Organization",
-            "format": "iri"
-          }
-        ]
+        "$ref": "#"
       }
     },
     "altLabel": {

--- a/jsonschema/definitions/QualityMeasurement.json
+++ b/jsonschema/definitions/QualityMeasurement.json
@@ -16,18 +16,7 @@
     "isMeasurementOf": {
       "title": "is measurement of",
       "description": "The metric being observed",
-      "anyOf": [
-        {
-          "$ref": "/dcat-us/3.0.0/definitions/metric",
-          "description": "inline description of Metric"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Metric",
-          "format": "iri"
-        }
-      ]
+      "$ref": "/dcat-us/3.0.0/definitions/metric"
     },
     "value": {
       "title": "value",

--- a/jsonschema/definitions/Standard.json
+++ b/jsonschema/definitions/Standard.json
@@ -66,12 +66,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/identifier",
           "description": "inline description of Identifier"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of Identifier",
-          "format": "iri"
         }
       ]
     },
@@ -80,18 +74,7 @@
       "description": "A list of identifiers for the Standard besides the main identifier, e.g. the URI or other unique identifiers in the context of the Catalog",
       "type": ["null", "array"],
       "items": {
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/identifier",
-            "description": "inline description of Identifier"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Identifier",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/identifier"
       }
     },
     "issued": {
@@ -174,19 +157,7 @@
       "description": "List of categories for the Standard",
       "type": ["null", "array"],
       "items": {
-        "title": "Category or link",
-        "anyOf": [
-          {
-            "$ref": "/dcat-us/3.0.0/definitions/concept",
-            "description": "inline description of Concept"
-          },
-          {
-            "type": "string",
-            "title": "Link",
-            "description": "reference iri of Concept",
-            "format": "iri"
-          }
-        ]
+        "$ref": "/dcat-us/3.0.0/definitions/concept"
       }
     },
     "inScheme": {
@@ -200,12 +171,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/conceptscheme",
           "description": "inline description of ConceptScheme"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of ConceptScheme",
-          "format": "iri"
         }
       ]
     }

--- a/jsonschema/definitions/UseRestriction.json
+++ b/jsonschema/definitions/UseRestriction.json
@@ -25,18 +25,7 @@
     "restrictionStatus": {
       "title": "restriction status",
       "description": "Indication of whether or not there are use restrictions on the archival materials",
-      "anyOf": [
-        {
-          "$ref": "/dcat-us/3.0.0/definitions/concept",
-          "description": "inline description of restriction status"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of restriction status",
-          "format": "iri"
-        }
-      ]
+      "$ref": "/dcat-us/3.0.0/definitions/concept"
     },
     "specificRestriction": {
       "title": "specific restriction",
@@ -49,12 +38,6 @@
         {
           "$ref": "/dcat-us/3.0.0/definitions/concept",
           "description": "inline description of the specific restriction"
-        },
-        {
-          "type": "string",
-          "title": "Link",
-          "description": "reference iri of the specific restriction",
-          "format": "iri"
         }
       ]
     }

--- a/jsonschema/docs/AccessRestriction.md
+++ b/jsonschema/docs/AccessRestriction.md
@@ -13,7 +13,7 @@ A restriction on the permitted access to a resource
 | - [@id](#@id )                                 | string             | -                    |
 | - [@type](#@type )                             | string             | -                    |
 | - [restrictionNote](#restrictionNote )         | null or string     | restriction note     |
-| + [restrictionStatus](#restrictionStatus )     | More than one type | restriction status   |
+| + [restrictionStatus](#restrictionStatus )     | object             | restriction status   |
 | - [specificRestriction](#specificRestriction ) | More than one type | specific restriction |
 
 ## <a name="@id"></a>Property `AccessRestriction > @id`

--- a/jsonschema/docs/AccessRestriction.md
+++ b/jsonschema/docs/AccessRestriction.md
@@ -14,7 +14,7 @@ A restriction on the permitted access to a resource
 | - [@type](#@type )                             | string             | -                                                                                         |
 | - [restrictionNote](#restrictionNote )         | null or string     | restriction note                                                                          |
 | - [restrictionNoteMap](#restrictionNoteMap )   | null or object     | Language map for the restriction note. E.g. {'es': 'spanish words', 'fr': 'french words'} |
-| + [restrictionStatus](#restrictionStatus )     | More than one type | restriction status                                                                        |
+| + [restrictionStatus](#restrictionStatus )     | object             | restriction status                                                                        |
 | - [specificRestriction](#specificRestriction ) | More than one type | specific restriction                                                                      |
 
 ## <a name="@id"></a>Property `AccessRestriction > @id`
@@ -51,36 +51,11 @@ Language map for the restriction note. E.g. {'es': 'spanish words', 'fr': 'frenc
 
 The indication of whether or not there are access restrictions on the item
 
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Required**              | Yes                |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                         |
-| -------------------------------------- |
-| [Concept](#restrictionStatus_anyOf_i0) |
-| [Link](#restrictionStatus_anyOf_i1)    |
-
-### <a name="restrictionStatus_anyOf_i0"></a>Property `AccessRestriction > restrictionStatus > anyOf > Concept`
-
-**Title:** Concept
-
-inline description of restriction status
-
 | **Type**                  | More than one type      |
 | ------------------------- | ----------------------- |
+| **Required**              | Yes                     |
 | **Additional properties** | Any type allowed        |
 | **Defined in**            | [Concept](./Concept.md) |
-
-### <a name="restrictionStatus_anyOf_i1"></a>Property `AccessRestriction > restrictionStatus > anyOf > Link`
-
-**Title:** Link
-
-reference iri of restriction status
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="specificRestriction"></a>Property `AccessRestriction > specificRestriction`
 
@@ -96,7 +71,6 @@ The specific NARA restriction associated with this restriction
 | --------------------------------------------------------------- |
 | [Null allowed when not required](#specificRestriction_anyOf_i0) |
 | [Concept](#specificRestriction_anyOf_i1)                        |
-| [Link](#specificRestriction_anyOf_i2)                           |
 
 ### <a name="specificRestriction_anyOf_i0"></a>Property `AccessRestriction > specificRestriction > anyOf > Null allowed when not required`
 
@@ -111,18 +85,8 @@ The specific NARA restriction associated with this restriction
 
 inline description of the specific restriction
 
-| **Type**                  | More than one type                     |
-| ------------------------- | -------------------------------------- |
-| **Additional properties** | Any type allowed                       |
-| **Same definition as**    | [Concept](#restrictionStatus_anyOf_i0) |
-
-### <a name="specificRestriction_anyOf_i2"></a>Property `AccessRestriction > specificRestriction > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the specific restriction
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                      |
+| ------------------------- | --------------------------------------- |
+| **Additional properties** | Any type allowed                        |
+| **Same definition as**    | [restrictionStatus](#restrictionStatus) |
 

--- a/jsonschema/docs/Activity.md
+++ b/jsonschema/docs/Activity.md
@@ -37,41 +37,20 @@ List of categories for the Activity
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be   | Description |
-| --------------------------------- | ----------- |
-| [category items](#category_items) | -           |
+| Each item of this array must be | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [Concept](#category_items)      | A labeled value from an optionally specified concept scheme |
 
-### <a name="category_items"></a>Activity > category > category items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Concept](#category_items_anyOf_i0) |
-| [Link](#category_items_anyOf_i1)    |
-
-#### <a name="category_items_anyOf_i0"></a>Property `Activity > category > category items > anyOf > Concept`
+### <a name="category_items"></a>Activity > category > Concept
 
 **Title:** Concept
 
-inline description of Concept
+A labeled value from an optionally specified concept scheme
 
 | **Type**                  | More than one type      |
 | ------------------------- | ----------------------- |
 | **Additional properties** | Any type allowed        |
 | **Defined in**            | [Concept](./Concept.md) |
-
-#### <a name="category_items_anyOf_i1"></a>Property `Activity > category > category items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="label"></a>Property `Activity > label`
 

--- a/jsonschema/docs/Agent.md
+++ b/jsonschema/docs/Agent.md
@@ -36,41 +36,20 @@ The type of the agent that makes the item available
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be   | Description |
-| --------------------------------- | ----------- |
-| [category items](#category_items) | -           |
+| Each item of this array must be | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [Concept](#category_items)      | A labeled value from an optionally specified concept scheme |
 
-### <a name="category_items"></a>Agent > category > category items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Concept](#category_items_anyOf_i0) |
-| [Link](#category_items_anyOf_i1)    |
-
-#### <a name="category_items_anyOf_i0"></a>Property `Agent > category > category items > anyOf > Concept`
+### <a name="category_items"></a>Agent > category > Concept
 
 **Title:** Concept
 
-inline description of Concept
+A labeled value from an optionally specified concept scheme
 
 | **Type**                  | More than one type      |
 | ------------------------- | ----------------------- |
 | **Additional properties** | Any type allowed        |
 | **Defined in**            | [Concept](./Concept.md) |
-
-#### <a name="category_items_anyOf_i1"></a>Property `Agent > category > category items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="name"></a>Property `Agent > name`
 

--- a/jsonschema/docs/Attribution.md
+++ b/jsonschema/docs/Attribution.md
@@ -8,12 +8,12 @@ An attribution that an agent plays some role
 | ------------------------- | ---------------- |
 | **Additional properties** | Any type allowed |
 
-| Property               | Type               | Title/Description |
-| ---------------------- | ------------------ | ----------------- |
-| - [@id](#@id )         | string             | -                 |
-| - [@type](#@type )     | string             | -                 |
-| + [hadRole](#hadRole ) | string             | role              |
-| + [agent](#agent )     | More than one type | agent             |
+| Property               | Type   | Title/Description |
+| ---------------------- | ------ | ----------------- |
+| - [@id](#@id )         | string | -                 |
+| - [@type](#@type )     | string | -                 |
+| + [hadRole](#hadRole ) | string | role              |
+| + [agent](#agent )     | object | agent             |
 
 ## <a name="@id"></a>Property `Attribution > @id`
 
@@ -43,34 +43,9 @@ The function of an entity or agent with respect to another entity or resource
 
 The agent that plays a role in the resource
 
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Required**              | Yes                |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)           |
-| ------------------------ |
-| [Agent](#agent_anyOf_i0) |
-| [Link](#agent_anyOf_i1)  |
-
-### <a name="agent_anyOf_i0"></a>Property `Attribution > agent > anyOf > Agent`
-
-**Title:** Agent
-
-inline description of Agent
-
 | **Type**                  | `object`            |
 | ------------------------- | ------------------- |
+| **Required**              | Yes                 |
 | **Additional properties** | Any type allowed    |
 | **Defined in**            | [Agent](./Agent.md) |
-
-### <a name="agent_anyOf_i1"></a>Property `Attribution > agent > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Agent
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 

--- a/jsonschema/docs/Catalog.md
+++ b/jsonschema/docs/Catalog.md
@@ -202,10 +202,10 @@ List of data services that are listed in the Catalog
 
 A service for providing data at a URL or URLs
 
-| **Type**                  | `object`                                                                |
-| ------------------------- | ----------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                        |
-| **Same definition as**    | [DataService](#dataset_items_sample_items_accessService_items_anyOf_i0) |
+| **Type**                  | `object`                                                       |
+| ------------------------- | -------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                               |
+| **Same definition as**    | [DataService](#dataset_items_sample_items_accessService_items) |
 
 ## <a name="theme"></a>Property `DCAT-US 3 Catalog > theme`
 
@@ -312,10 +312,10 @@ An established standard to which the described catalog conforms
 
 Information about a particular standard that another item conforms to
 
-| **Type**                  | `object`                                                                              |
-| ------------------------- | ------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                      |
-| **Same definition as**    | [Standard](#dataset_items_sample_items_accessService_items_anyOf_i0_conformsTo_items) |
+| **Type**                  | `object`                                                                     |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                             |
+| **Same definition as**    | [Standard](#dataset_items_sample_items_accessService_items_conformsTo_items) |
 
 ## <a name="creator"></a>Property `DCAT-US 3 Catalog > creator`
 
@@ -336,10 +336,10 @@ The entity responsible for creating the resource
 
 An entity that could be involved with a resource
 
-| **Type**                  | `object`                                                                        |
-| ------------------------- | ------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                |
-| **Same definition as**    | [Agent](#dataset_items_sample_items_accessService_items_anyOf_i0_creator_items) |
+| **Type**                  | `object`                                                               |
+| ------------------------- | ---------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                       |
+| **Same definition as**    | [Agent](#dataset_items_sample_items_accessService_items_creator_items) |
 
 ## <a name="description"></a>Property `DCAT-US 3 Catalog > description`
 
@@ -693,10 +693,10 @@ Agent responsible for making the catalog available
 
 inline description of the publisher
 
-| **Type**                  | `object`                                                                        |
-| ------------------------- | ------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                |
-| **Same definition as**    | [Agent](#dataset_items_sample_items_accessService_items_anyOf_i0_creator_items) |
+| **Type**                  | `object`                                                               |
+| ------------------------- | ---------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                       |
+| **Same definition as**    | [Agent](#dataset_items_sample_items_accessService_items_creator_items) |
 
 ## <a name="rights"></a>Property `DCAT-US 3 Catalog > rights`
 
@@ -761,10 +761,10 @@ The geographical area covered by the catalog
 
 Information about a specific geographic location
 
-| **Type**                  | `object`                                                                           |
-| ------------------------- | ---------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                   |
-| **Same definition as**    | [Location](#dataset_items_sample_items_accessService_items_anyOf_i0_spatial_items) |
+| **Type**                  | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                          |
+| **Same definition as**    | [Location](#dataset_items_sample_items_accessService_items_spatial_items) |
 
 ## <a name="subject"></a>Property `DCAT-US 3 Catalog > subject`
 
@@ -809,10 +809,10 @@ List of temporal periods that the Catalog covers
 
 Information about a specific time period with a start- and/or end-time
 
-| **Type**                  | `object`                                                                                |
-| ------------------------- | --------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                        |
-| **Same definition as**    | [PeriodOfTime](#dataset_items_sample_items_accessService_items_anyOf_i0_temporal_items) |
+| **Type**                  | `object`                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                                               |
+| **Same definition as**    | [PeriodOfTime](#dataset_items_sample_items_accessService_items_temporal_items) |
 
 ## <a name="title"></a>Property `DCAT-US 3 Catalog > title`
 
@@ -906,8 +906,8 @@ A list of agents having some form of responsibility for the catalog
 
 An attribution that an agent plays some role
 
-| **Type**                  | `object`                                                                                           |
-| ------------------------- | -------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                   |
-| **Same definition as**    | [Attribution](#dataset_items_sample_items_accessService_items_anyOf_i0_qualifiedAttribution_items) |
+| **Type**                  | `object`                                                                                  |
+| ------------------------- | ----------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                          |
+| **Same definition as**    | [Attribution](#dataset_items_sample_items_accessService_items_qualifiedAttribution_items) |
 

--- a/jsonschema/docs/Catalog.md
+++ b/jsonschema/docs/Catalog.md
@@ -32,7 +32,7 @@ The main item defined by DCAT-US 3 is the Catalog class
 | - [license](#license )                           | More than one type      | license                     |
 | - [modified](#modified )                         | More than one type      | update/modification date    |
 | - [publisher](#publisher )                       | More than one type      | publisher                   |
-| - [rights](#rights )                             | null or array           | rights                      |
+| - [rights](#rights )                             | null or array of string | rights                      |
 | - [rightsHolder](#rightsHolder )                 | null or array           | rights holder               |
 | - [spatial](#spatial )                           | null or array           | spatial/geographic coverage |
 | - [subject](#subject )                           | null or array           | subject                     |

--- a/jsonschema/docs/Catalog.md
+++ b/jsonschema/docs/Catalog.md
@@ -34,7 +34,7 @@ The main item defined by DCAT-US 3 is the Catalog class
 | - [license](#license )                           | More than one type      | license                                                                             |
 | - [modified](#modified )                         | More than one type      | update/modification date                                                            |
 | - [publisher](#publisher )                       | More than one type      | publisher                                                                           |
-| - [rights](#rights )                             | null or array           | rights                                                                              |
+| - [rights](#rights )                             | null or array of string | rights                                                                              |
 | - [rightsHolder](#rightsHolder )                 | null or array           | rights holder                                                                       |
 | - [spatial](#spatial )                           | null or array           | spatial/geographic coverage                                                         |
 | - [subject](#subject )                           | null or array           | subject                                                                             |
@@ -66,41 +66,20 @@ List of related catalogs whose contents are of interest in the context of this c
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be     | Description |
-| ----------------------------------- | ----------- |
-| [Catalog or a link](#catalog_items) | -           |
+| Each item of this array must be     | Description                                             |
+| ----------------------------------- | ------------------------------------------------------- |
+| [DCAT-US 3 Catalog](#catalog_items) | The main item defined by DCAT-US 3 is the Catalog class |
 
-### <a name="catalog_items"></a>DCAT-US 3 Catalog > catalog > Catalog or a link
+### <a name="catalog_items"></a>DCAT-US 3 Catalog > catalog > DCAT-US 3 Catalog
 
-**Title:** Catalog or a link
+**Title:** DCAT-US 3 Catalog
 
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
+The main item defined by DCAT-US 3 is the Catalog class
 
-| Any of(Option)                     |
-| ---------------------------------- |
-| [catalog](#catalog_items_anyOf_i0) |
-| [Link](#catalog_items_anyOf_i1)    |
-
-#### <a name="catalog_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > catalog > Catalog or a link > anyOf > catalog`
-
-inline description of Catalog
-
-| **Type**                  | `object`                |
-| ------------------------- | ----------------------- |
-| **Additional properties** | Any type allowed        |
-| **Defined in**            | [Catalog](./Catalog.md) |
-
-#### <a name="catalog_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > catalog > Catalog or a link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Catalog
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                   |
+| ------------------------- | -------------------------- |
+| **Additional properties** | Any type allowed           |
+| **Same definition as**    | [DCAT-US 3 Catalog](#root) |
 
 ## <a name="contactPoint"></a>Property `DCAT-US 3 Catalog > contactPoint`
 
@@ -111,43 +90,20 @@ Contact information that can be used for sending comments about the Catalog
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [Contact point or a link](#contactPoint_items) | -           |
+| Each item of this array must be | Description                                     |
+| ------------------------------- | ----------------------------------------------- |
+| [Kind](#contactPoint_items)     | Contact information for an individual or entity |
 
-### <a name="contactPoint_items"></a>DCAT-US 3 Catalog > contactPoint > Contact point or a link
-
-**Title:** Contact point or a link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                       |
-| ------------------------------------ |
-| [Kind](#contactPoint_items_anyOf_i0) |
-| [Link](#contactPoint_items_anyOf_i1) |
-
-#### <a name="contactPoint_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > contactPoint > Contact point or a link > anyOf > Kind`
+### <a name="contactPoint_items"></a>DCAT-US 3 Catalog > contactPoint > Kind
 
 **Title:** Kind
 
-inline value for contact point
+Contact information for an individual or entity
 
 | **Type**                  | `object`          |
 | ------------------------- | ----------------- |
 | **Additional properties** | Any type allowed  |
 | **Defined in**            | [Kind](./Kind.md) |
-
-#### <a name="contactPoint_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > contactPoint > Contact point or a link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of contact point
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="dataset"></a>Property `DCAT-US 3 Catalog > dataset`
 
@@ -159,41 +115,20 @@ List of Datasets that are part of the Catalog
 | ------------ | ------- |
 | **Required** | Yes     |
 
-| Each item of this array must be | Description |
-| ------------------------------- | ----------- |
-| [dataset items](#dataset_items) | -           |
+| Each item of this array must be | Description                     |
+| ------------------------------- | ------------------------------- |
+| [Dataset](#dataset_items)       | Information about a set of data |
 
-### <a name="dataset_items"></a>DCAT-US 3 Catalog > dataset > dataset items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                     |
-| ---------------------------------- |
-| [Dataset](#dataset_items_anyOf_i0) |
-| [Link](#dataset_items_anyOf_i1)    |
-
-#### <a name="dataset_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > dataset > dataset items > anyOf > Dataset`
+### <a name="dataset_items"></a>DCAT-US 3 Catalog > dataset > Dataset
 
 **Title:** Dataset
 
-inline description of Dataset
+Information about a set of data
 
 | **Type**                  | `object`                |
 | ------------------------- | ----------------------- |
 | **Additional properties** | Any type allowed        |
 | **Defined in**            | [Dataset](./Dataset.md) |
-
-#### <a name="dataset_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > dataset > dataset items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Dataset
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="keyword"></a>Property `DCAT-US 3 Catalog > keyword`
 
@@ -233,41 +168,20 @@ A record describing a single resource (e.g., a dataset, a data service) that is 
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be | Description |
-| ------------------------------- | ----------- |
-| [record items](#record_items)   | -           |
+| Each item of this array must be | Description                                                             |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| [CatalogRecord](#record_items)  | A record in a catalog, describing the registration of a single resource |
 
-### <a name="record_items"></a>DCAT-US 3 Catalog > record > record items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                          |
-| --------------------------------------- |
-| [CatalogRecord](#record_items_anyOf_i0) |
-| [Link](#record_items_anyOf_i1)          |
-
-#### <a name="record_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > record > record items > anyOf > CatalogRecord`
+### <a name="record_items"></a>DCAT-US 3 Catalog > record > CatalogRecord
 
 **Title:** CatalogRecord
 
-inline description of the record
+A record in a catalog, describing the registration of a single resource
 
 | **Type**                  | `object`                            |
 | ------------------------- | ----------------------------------- |
 | **Additional properties** | Any type allowed                    |
 | **Defined in**            | [Catalogrecord](./Catalogrecord.md) |
-
-#### <a name="record_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > record > record items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the record
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="service"></a>Property `DCAT-US 3 Catalog > service`
 
@@ -278,41 +192,20 @@ List of data services that are listed in the Catalog
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be | Description |
-| ------------------------------- | ----------- |
-| [service items](#service_items) | -           |
+| Each item of this array must be | Description                                   |
+| ------------------------------- | --------------------------------------------- |
+| [DataService](#service_items)   | A service for providing data at a URL or URLs |
 
-### <a name="service_items"></a>DCAT-US 3 Catalog > service > service items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                         |
-| -------------------------------------- |
-| [DataService](#service_items_anyOf_i0) |
-| [Link](#service_items_anyOf_i1)        |
-
-#### <a name="service_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > service > service items > anyOf > DataService`
+### <a name="service_items"></a>DCAT-US 3 Catalog > service > DataService
 
 **Title:** DataService
 
-inline description of the service
+A service for providing data at a URL or URLs
 
-| **Type**                  | `object`                                                                                  |
-| ------------------------- | ----------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                          |
-| **Same definition as**    | [DataService](#dataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0) |
-
-#### <a name="service_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > service > service items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the service
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                |
+| ------------------------- | ----------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                        |
+| **Same definition as**    | [DataService](#dataset_items_sample_items_accessService_items_anyOf_i0) |
 
 ## <a name="theme"></a>Property `DCAT-US 3 Catalog > theme`
 
@@ -323,41 +216,20 @@ A list of categories for the Catalog. A Catalog may be associated with multiple 
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be | Description |
-| ------------------------------- | ----------- |
-| [theme items](#theme_items)     | -           |
+| Each item of this array must be | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [Concept](#theme_items)         | A labeled value from an optionally specified concept scheme |
 
-### <a name="theme_items"></a>DCAT-US 3 Catalog > theme > theme items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                   |
-| -------------------------------- |
-| [Concept](#theme_items_anyOf_i0) |
-| [Link](#theme_items_anyOf_i1)    |
-
-#### <a name="theme_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > theme > theme items > anyOf > Concept`
+### <a name="theme_items"></a>DCAT-US 3 Catalog > theme > Concept
 
 **Title:** Concept
 
-inline description of the theme
+A labeled value from an optionally specified concept scheme
 
-| **Type**                  | More than one type                                                                        |
-| ------------------------- | ----------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                          |
-| **Same definition as**    | [Concept](#dataset_items_anyOf_i0_sample_items_anyOf_i0_representationTechnique_anyOf_i1) |
-
-#### <a name="theme_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > theme > theme items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the theme
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                                      |
+| ------------------------- | ----------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                        |
+| **Same definition as**    | [Concept](#dataset_items_sample_items_representationTechnique_anyOf_i1) |
 
 ## <a name="themeTaxonomy"></a>Property `DCAT-US 3 Catalog > themeTaxonomy`
 
@@ -368,41 +240,20 @@ A knowledge organization system (KOS) used to classify the resources documented 
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be             | Description |
-| ------------------------------------------- | ----------- |
-| [themeTaxonomy items](#themeTaxonomy_items) | -           |
+| Each item of this array must be       | Description                                                  |
+| ------------------------------------- | ------------------------------------------------------------ |
+| [ConceptScheme](#themeTaxonomy_items) | A system for specifying approved values for a single concept |
 
-### <a name="themeTaxonomy_items"></a>DCAT-US 3 Catalog > themeTaxonomy > themeTaxonomy items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                 |
-| ---------------------------------------------- |
-| [ConceptScheme](#themeTaxonomy_items_anyOf_i0) |
-| [Link](#themeTaxonomy_items_anyOf_i1)          |
-
-#### <a name="themeTaxonomy_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > themeTaxonomy > themeTaxonomy items > anyOf > ConceptScheme`
+### <a name="themeTaxonomy_items"></a>DCAT-US 3 Catalog > themeTaxonomy > ConceptScheme
 
 **Title:** ConceptScheme
 
-inline description of ConceptScheme
+A system for specifying approved values for a single concept
 
-| **Type**                  | `object`                                                                                                                   |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                           |
-| **Same definition as**    | [ConceptScheme](#dataset_items_anyOf_i0_sample_items_anyOf_i0_representationTechnique_anyOf_i1_anyOf_i1_inScheme_anyOf_i0) |
-
-#### <a name="themeTaxonomy_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > themeTaxonomy > themeTaxonomy items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of ConceptScheme
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                   |
+| ------------------------- | ------------------------------------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                                                           |
+| **Same definition as**    | [inScheme](#dataset_items_sample_items_representationTechnique_anyOf_i1_anyOf_i1_inScheme) |
 
 ## <a name="accessRights"></a>Property `DCAT-US 3 Catalog > accessRights`
 
@@ -418,7 +269,6 @@ Information that indicates whether the Catalog is open data, has access restrict
 | -------------------------------------------------------- |
 | [Null allowed when not required](#accessRights_anyOf_i0) |
 | [item 1](#accessRights_anyOf_i1)                         |
-| [Link](#accessRights_anyOf_i2)                           |
 
 ### <a name="accessRights_anyOf_i0"></a>Property `DCAT-US 3 Catalog > accessRights > anyOf > Null allowed when not required`
 
@@ -434,16 +284,6 @@ Text description of the access rights
 | **Type** | `string` |
 | -------- | -------- |
 
-### <a name="accessRights_anyOf_i2"></a>Property `DCAT-US 3 Catalog > accessRights > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the access rights
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
 ## <a name="conformsTo"></a>Property `DCAT-US 3 Catalog > conformsTo`
 
 **Title:** schema version
@@ -458,7 +298,6 @@ An established standard to which the described catalog conforms
 | ------------------------------------------------------ |
 | [Null allowed when not required](#conformsTo_anyOf_i0) |
 | [Standard](#conformsTo_anyOf_i1)                       |
-| [Link](#conformsTo_anyOf_i2)                           |
 
 ### <a name="conformsTo_anyOf_i0"></a>Property `DCAT-US 3 Catalog > conformsTo > anyOf > Null allowed when not required`
 
@@ -471,22 +310,12 @@ An established standard to which the described catalog conforms
 
 **Title:** Standard
 
-inline description of Standard
+Information about a particular standard that another item conforms to
 
-| **Type**                  | `object`                                                                                                         |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                 |
-| **Same definition as**    | [Standard](#dataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_conformsTo_items_anyOf_i0) |
-
-### <a name="conformsTo_anyOf_i2"></a>Property `DCAT-US 3 Catalog > conformsTo > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Standard
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                      |
+| **Same definition as**    | [Standard](#dataset_items_sample_items_accessService_items_anyOf_i0_conformsTo_items) |
 
 ## <a name="creator"></a>Property `DCAT-US 3 Catalog > creator`
 
@@ -497,41 +326,20 @@ The entity responsible for creating the resource
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be | Description |
-| ------------------------------- | ----------- |
-| [creator items](#creator_items) | -           |
+| Each item of this array must be | Description                                      |
+| ------------------------------- | ------------------------------------------------ |
+| [Agent](#creator_items)         | An entity that could be involved with a resource |
 
-### <a name="creator_items"></a>DCAT-US 3 Catalog > creator > creator items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                   |
-| -------------------------------- |
-| [Agent](#creator_items_anyOf_i0) |
-| [Link](#creator_items_anyOf_i1)  |
-
-#### <a name="creator_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > creator > creator items > anyOf > Agent`
+### <a name="creator_items"></a>DCAT-US 3 Catalog > creator > Agent
 
 **Title:** Agent
 
-inline description of creator
+An entity that could be involved with a resource
 
-| **Type**                  | `object`                                                                                                   |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                           |
-| **Same definition as**    | [Agent](#dataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_creator_items_anyOf_i0) |
-
-#### <a name="creator_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > creator > creator items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of creator
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                |
+| **Same definition as**    | [Agent](#dataset_items_sample_items_accessService_items_anyOf_i0_creator_items) |
 
 ## <a name="description"></a>Property `DCAT-US 3 Catalog > description`
 
@@ -558,41 +366,20 @@ A list of related catalogs that are part of the described catalog
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be | Description |
-| ------------------------------- | ----------- |
-| [hasPart items](#hasPart_items) | -           |
+| Each item of this array must be     | Description                                             |
+| ----------------------------------- | ------------------------------------------------------- |
+| [DCAT-US 3 Catalog](#hasPart_items) | The main item defined by DCAT-US 3 is the Catalog class |
 
-### <a name="hasPart_items"></a>DCAT-US 3 Catalog > hasPart > hasPart items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                               |
-| -------------------------------------------- |
-| [DCAT-US 3 Catalog](#hasPart_items_anyOf_i0) |
-| [Link](#hasPart_items_anyOf_i1)              |
-
-#### <a name="hasPart_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > hasPart > hasPart items > anyOf > DCAT-US 3 Catalog`
+### <a name="hasPart_items"></a>DCAT-US 3 Catalog > hasPart > DCAT-US 3 Catalog
 
 **Title:** DCAT-US 3 Catalog
 
-inline description of the related catalog
+The main item defined by DCAT-US 3 is the Catalog class
 
 | **Type**                  | `object`                   |
 | ------------------------- | -------------------------- |
 | **Additional properties** | Any type allowed           |
 | **Same definition as**    | [DCAT-US 3 Catalog](#root) |
-
-#### <a name="hasPart_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > hasPart > hasPart items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the related catalog
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="identifier"></a>Property `DCAT-US 3 Catalog > identifier`
 
@@ -608,7 +395,6 @@ The unique identifier for the Catalog, e.g. the URI or other unique identifier
 | ------------------------------------------------------ |
 | [Null allowed when not required](#identifier_anyOf_i0) |
 | [Identifier](#identifier_anyOf_i1)                     |
-| [Link](#identifier_anyOf_i2)                           |
 
 ### <a name="identifier_anyOf_i0"></a>Property `DCAT-US 3 Catalog > identifier > anyOf > Null allowed when not required`
 
@@ -623,20 +409,10 @@ The unique identifier for the Catalog, e.g. the URI or other unique identifier
 
 inline description of Identifier
 
-| **Type**                  | More than one type                                                   |
-| ------------------------- | -------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                     |
-| **Same definition as**    | [Identifier](#dataset_items_anyOf_i0_otherIdentifier_items_anyOf_i0) |
-
-### <a name="identifier_anyOf_i2"></a>Property `DCAT-US 3 Catalog > identifier > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                 |
+| ------------------------- | -------------------------------------------------- |
+| **Additional properties** | Any type allowed                                   |
+| **Same definition as**    | [Identifier](#dataset_items_otherIdentifier_items) |
 
 ## <a name="otherIdentifier"></a>Property `DCAT-US 3 Catalog > otherIdentifier`
 
@@ -647,41 +423,20 @@ A list of identifiers for the Catalog besides the main identifier, e.g. the URI 
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                 | Description |
-| ----------------------------------------------- | ----------- |
-| [otherIdentifier items](#otherIdentifier_items) | -           |
+| Each item of this array must be      | Description                                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------- |
+| [Identifier](#otherIdentifier_items) | A unique identifier and optionally it's scheme and other relevant information |
 
-### <a name="otherIdentifier_items"></a>DCAT-US 3 Catalog > otherIdentifier > otherIdentifier items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                |
-| --------------------------------------------- |
-| [Identifier](#otherIdentifier_items_anyOf_i0) |
-| [Link](#otherIdentifier_items_anyOf_i1)       |
-
-#### <a name="otherIdentifier_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > otherIdentifier > otherIdentifier items > anyOf > Identifier`
+### <a name="otherIdentifier_items"></a>DCAT-US 3 Catalog > otherIdentifier > Identifier
 
 **Title:** Identifier
 
-inline description of Identifier
+A unique identifier and optionally it's scheme and other relevant information
 
-| **Type**                  | More than one type                                                   |
-| ------------------------- | -------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                     |
-| **Same definition as**    | [Identifier](#dataset_items_anyOf_i0_otherIdentifier_items_anyOf_i0) |
-
-#### <a name="otherIdentifier_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > otherIdentifier > otherIdentifier items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                 |
+| ------------------------- | -------------------------------------------------- |
+| **Additional properties** | Any type allowed                                   |
+| **Same definition as**    | [Identifier](#dataset_items_otherIdentifier_items) |
 
 ## <a name="issued"></a>Property `DCAT-US 3 Catalog > issued`
 
@@ -824,7 +579,6 @@ The license under which the Catalog is made available; see https://resources.dat
 | --------------------------------------------------- |
 | [Null allowed when not required](#license_anyOf_i0) |
 | [item 1](#license_anyOf_i1)                         |
-| [Link](#license_anyOf_i2)                           |
 
 ### <a name="license_anyOf_i0"></a>Property `DCAT-US 3 Catalog > license > anyOf > Null allowed when not required`
 
@@ -839,16 +593,6 @@ Full text of the license
 
 | **Type** | `string` |
 | -------- | -------- |
-
-### <a name="license_anyOf_i2"></a>Property `DCAT-US 3 Catalog > license > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the license
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="modified"></a>Property `DCAT-US 3 Catalog > modified`
 
@@ -935,7 +679,6 @@ Agent responsible for making the catalog available
 | ----------------------------------------------------- |
 | [Null allowed when not required](#publisher_anyOf_i0) |
 | [Agent](#publisher_anyOf_i1)                          |
-| [Link](#publisher_anyOf_i2)                           |
 
 ### <a name="publisher_anyOf_i0"></a>Property `DCAT-US 3 Catalog > publisher > anyOf > Null allowed when not required`
 
@@ -950,20 +693,10 @@ Agent responsible for making the catalog available
 
 inline description of the publisher
 
-| **Type**                  | `object`                                                                                                   |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                           |
-| **Same definition as**    | [Agent](#dataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_creator_items_anyOf_i0) |
-
-### <a name="publisher_anyOf_i2"></a>Property `DCAT-US 3 Catalog > publisher > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the publisher
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                |
+| **Same definition as**    | [Agent](#dataset_items_sample_items_accessService_items_anyOf_i0_creator_items) |
 
 ## <a name="rights"></a>Property `DCAT-US 3 Catalog > rights`
 
@@ -971,42 +704,19 @@ reference iri of the publisher
 
 A list of statements concerning all rights for the Catalog that may not be addressed by license or accessRights, such as copyright statements, statements about the intellectual property rights (IPR), or information regarding access or restrictions based on privacy, security, or other policies
 
-| **Type** | `null or array` |
-| -------- | --------------- |
+| **Type** | `null or array of string` |
+| -------- | ------------------------- |
 
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [Rights statement text or link](#rights_items) | -           |
+| Each item of this array must be | Description                        |
+| ------------------------------- | ---------------------------------- |
+| [rights items](#rights_items)   | Full text of a statement of rights |
 
-### <a name="rights_items"></a>DCAT-US 3 Catalog > rights > Rights statement text or link
-
-**Title:** Rights statement text or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                   |
-| -------------------------------- |
-| [item 0](#rights_items_anyOf_i0) |
-| [Link](#rights_items_anyOf_i1)   |
-
-#### <a name="rights_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > rights > Rights statement text or link > anyOf > item 0`
+### <a name="rights_items"></a>DCAT-US 3 Catalog > rights > rights items
 
 Full text of a statement of rights
 
 | **Type** | `string` |
 | -------- | -------- |
-
-#### <a name="rights_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > rights > Rights statement text or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of a statement of rights
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="rightsHolder"></a>Property `DCAT-US 3 Catalog > rightsHolder`
 
@@ -1017,41 +727,20 @@ List of organizations holding rights on the catalog
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be           | Description |
-| ----------------------------------------- | ----------- |
-| [rightsHolder items](#rightsHolder_items) | -           |
+| Each item of this array must be     | Description                                                                         |
+| ----------------------------------- | ----------------------------------------------------------------------------------- |
+| [Organization](#rightsHolder_items) | Information about an organization, including other organizations that it is part of |
 
-### <a name="rightsHolder_items"></a>DCAT-US 3 Catalog > rightsHolder > rightsHolder items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                               |
-| -------------------------------------------- |
-| [Organization](#rightsHolder_items_anyOf_i0) |
-| [Link](#rightsHolder_items_anyOf_i1)         |
-
-#### <a name="rightsHolder_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > rightsHolder > rightsHolder items > anyOf > Organization`
+### <a name="rightsHolder_items"></a>DCAT-US 3 Catalog > rightsHolder > Organization
 
 **Title:** Organization
 
-inline description of rights holder
+Information about an organization, including other organizations that it is part of
 
-| **Type**                  | `object`                                                                                         |
-| ------------------------- | ------------------------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                                                 |
-| **Same definition as**    | [Organization](#dataset_items_anyOf_i0_otherIdentifier_items_anyOf_i0_anyOf_i1_creator_anyOf_i1) |
-
-#### <a name="rightsHolder_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > rightsHolder > rightsHolder items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of rights holder
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                                               |
+| **Same definition as**    | [Organization](#dataset_items_otherIdentifier_items_anyOf_i1_creator_anyOf_i1) |
 
 ## <a name="spatial"></a>Property `DCAT-US 3 Catalog > spatial`
 
@@ -1062,41 +751,20 @@ The geographical area covered by the catalog
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be | Description |
-| ------------------------------- | ----------- |
-| [spatial items](#spatial_items) | -           |
+| Each item of this array must be | Description                                      |
+| ------------------------------- | ------------------------------------------------ |
+| [Location](#spatial_items)      | Information about a specific geographic location |
 
-### <a name="spatial_items"></a>DCAT-US 3 Catalog > spatial > spatial items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Location](#spatial_items_anyOf_i0) |
-| [Link](#spatial_items_anyOf_i1)     |
-
-#### <a name="spatial_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > spatial > spatial items > anyOf > Location`
+### <a name="spatial_items"></a>DCAT-US 3 Catalog > spatial > Location
 
 **Title:** Location
 
-inline description of geographical coverage
+Information about a specific geographic location
 
-| **Type**                  | `object`                                                                                                      |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                              |
-| **Same definition as**    | [Location](#dataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_spatial_items_anyOf_i0) |
-
-#### <a name="spatial_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > spatial > spatial items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of geographical coverage
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                           |
+| ------------------------- | ---------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                   |
+| **Same definition as**    | [Location](#dataset_items_sample_items_accessService_items_anyOf_i0_spatial_items) |
 
 ## <a name="subject"></a>Property `DCAT-US 3 Catalog > subject`
 
@@ -1107,41 +775,20 @@ List of subjects of the catalog
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be | Description |
-| ------------------------------- | ----------- |
-| [subject items](#subject_items) | -           |
+| Each item of this array must be | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [Concept](#subject_items)       | A labeled value from an optionally specified concept scheme |
 
-### <a name="subject_items"></a>DCAT-US 3 Catalog > subject > subject items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                     |
-| ---------------------------------- |
-| [Concept](#subject_items_anyOf_i0) |
-| [Link](#subject_items_anyOf_i1)    |
-
-#### <a name="subject_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > subject > subject items > anyOf > Concept`
+### <a name="subject_items"></a>DCAT-US 3 Catalog > subject > Concept
 
 **Title:** Concept
 
-inline description of the subject
+A labeled value from an optionally specified concept scheme
 
-| **Type**                  | More than one type                                                                        |
-| ------------------------- | ----------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                          |
-| **Same definition as**    | [Concept](#dataset_items_anyOf_i0_sample_items_anyOf_i0_representationTechnique_anyOf_i1) |
-
-#### <a name="subject_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > subject > subject items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the subject
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                                      |
+| ------------------------- | ----------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                        |
+| **Same definition as**    | [Concept](#dataset_items_sample_items_representationTechnique_anyOf_i1) |
 
 ## <a name="temporal"></a>Property `DCAT-US 3 Catalog > temporal`
 
@@ -1152,41 +799,20 @@ List of temporal periods that the Catalog covers
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be   | Description |
-| --------------------------------- | ----------- |
-| [temporal items](#temporal_items) | -           |
+| Each item of this array must be | Description                                                            |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| [PeriodOfTime](#temporal_items) | Information about a specific time period with a start- and/or end-time |
 
-### <a name="temporal_items"></a>DCAT-US 3 Catalog > temporal > temporal items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                           |
-| ---------------------------------------- |
-| [PeriodOfTime](#temporal_items_anyOf_i0) |
-| [Link](#temporal_items_anyOf_i1)         |
-
-#### <a name="temporal_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > temporal > temporal items > anyOf > PeriodOfTime`
+### <a name="temporal_items"></a>DCAT-US 3 Catalog > temporal > PeriodOfTime
 
 **Title:** PeriodOfTime
 
-inline description of the temporal coverage
+Information about a specific time period with a start- and/or end-time
 
-| **Type**                  | `object`                                                                                                           |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                                                                   |
-| **Same definition as**    | [PeriodOfTime](#dataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_temporal_items_anyOf_i0) |
-
-#### <a name="temporal_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > temporal > temporal items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the temporal coverage
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                |
+| ------------------------- | --------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                        |
+| **Same definition as**    | [PeriodOfTime](#dataset_items_sample_items_accessService_items_anyOf_i0_temporal_items) |
 
 ## <a name="title"></a>Property `DCAT-US 3 Catalog > title`
 
@@ -1213,41 +839,20 @@ List of categories for the Catalog
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be   | Description |
-| --------------------------------- | ----------- |
-| [category items](#category_items) | -           |
+| Each item of this array must be | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [Concept](#category_items)      | A labeled value from an optionally specified concept scheme |
 
-### <a name="category_items"></a>DCAT-US 3 Catalog > category > category items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Concept](#category_items_anyOf_i0) |
-| [Link](#category_items_anyOf_i1)    |
-
-#### <a name="category_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > category > category items > anyOf > Concept`
+### <a name="category_items"></a>DCAT-US 3 Catalog > category > Concept
 
 **Title:** Concept
 
-inline description of Concept
+A labeled value from an optionally specified concept scheme
 
-| **Type**                  | More than one type                                                                        |
-| ------------------------- | ----------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                          |
-| **Same definition as**    | [Concept](#dataset_items_anyOf_i0_sample_items_anyOf_i0_representationTechnique_anyOf_i1) |
-
-#### <a name="category_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > category > category items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                                      |
+| ------------------------- | ----------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                        |
+| **Same definition as**    | [Concept](#dataset_items_sample_items_representationTechnique_anyOf_i1) |
 
 ## <a name="homepage"></a>Property `DCAT-US 3 Catalog > homepage`
 
@@ -1263,7 +868,6 @@ The home page of the catalog (a public Web document usually available in HTML)
 | ---------------------------------------------------- |
 | [Null allowed when not required](#homepage_anyOf_i0) |
 | [Document](#homepage_anyOf_i1)                       |
-| [Link](#homepage_anyOf_i2)                           |
 
 ### <a name="homepage_anyOf_i0"></a>Property `DCAT-US 3 Catalog > homepage > anyOf > Null allowed when not required`
 
@@ -1278,20 +882,10 @@ The home page of the catalog (a public Web document usually available in HTML)
 
 inline description of the home page
 
-| **Type**                  | `object`                                                                      |
-| ------------------------- | ----------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                              |
-| **Same definition as**    | [Document](#dataset_items_anyOf_i0_sample_items_anyOf_i0_page_items_anyOf_i0) |
-
-### <a name="homepage_anyOf_i2"></a>Property `DCAT-US 3 Catalog > homepage > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the home page
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                           |
+| ------------------------- | -------------------------------------------------- |
+| **Additional properties** | Any type allowed                                   |
+| **Same definition as**    | [Document](#dataset_items_sample_items_page_items) |
 
 ## <a name="qualifiedAttribution"></a>Property `DCAT-US 3 Catalog > qualifiedAttribution`
 
@@ -1302,39 +896,18 @@ A list of agents having some form of responsibility for the catalog
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                           | Description |
-| --------------------------------------------------------- | ----------- |
-| [qualifiedAttribution items](#qualifiedAttribution_items) | -           |
+| Each item of this array must be            | Description                                  |
+| ------------------------------------------ | -------------------------------------------- |
+| [Attribution](#qualifiedAttribution_items) | An attribution that an agent plays some role |
 
-### <a name="qualifiedAttribution_items"></a>DCAT-US 3 Catalog > qualifiedAttribution > qualifiedAttribution items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                      |
-| --------------------------------------------------- |
-| [Attribution](#qualifiedAttribution_items_anyOf_i0) |
-| [Link](#qualifiedAttribution_items_anyOf_i1)        |
-
-#### <a name="qualifiedAttribution_items_anyOf_i0"></a>Property `DCAT-US 3 Catalog > qualifiedAttribution > qualifiedAttribution items > anyOf > Attribution`
+### <a name="qualifiedAttribution_items"></a>DCAT-US 3 Catalog > qualifiedAttribution > Attribution
 
 **Title:** Attribution
 
-inline description of Attribution
+An attribution that an agent plays some role
 
-| **Type**                  | `object`                                                                                                                      |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                              |
-| **Same definition as**    | [Attribution](#dataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_qualifiedAttribution_items_anyOf_i0) |
-
-#### <a name="qualifiedAttribution_items_anyOf_i1"></a>Property `DCAT-US 3 Catalog > qualifiedAttribution > qualifiedAttribution items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Attribution
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                           |
+| ------------------------- | -------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                   |
+| **Same definition as**    | [Attribution](#dataset_items_sample_items_accessService_items_anyOf_i0_qualifiedAttribution_items) |
 

--- a/jsonschema/docs/CatalogRecord.md
+++ b/jsonschema/docs/CatalogRecord.md
@@ -49,7 +49,6 @@ The status of the catalog record in the context of editorial flow of the dataset
 | -------------------------------------------------- |
 | [Null allowed when not required](#status_anyOf_i0) |
 | [Concept](#status_anyOf_i1)                        |
-| [Link](#status_anyOf_i2)                           |
 
 ### <a name="status_anyOf_i0"></a>Property `CatalogRecord > status > anyOf > Null allowed when not required`
 
@@ -69,16 +68,6 @@ inline description of status
 | **Additional properties** | Any type allowed        |
 | **Defined in**            | [Concept](./Concept.md) |
 
-### <a name="status_anyOf_i2"></a>Property `CatalogRecord > status > anyOf > Link`
-
-**Title:** Link
-
-reference iri of status
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
 ## <a name="conformsTo"></a>Property `CatalogRecord > conformsTo`
 
 **Title:** application profile
@@ -93,7 +82,6 @@ An Application Profile that the Catalog Record's metadata conforms to
 | ------------------------------------------------------ |
 | [Null allowed when not required](#conformsTo_anyOf_i0) |
 | [Standard](#conformsTo_anyOf_i1)                       |
-| [Link](#conformsTo_anyOf_i2)                           |
 
 ### <a name="conformsTo_anyOf_i0"></a>Property `CatalogRecord > conformsTo > anyOf > Null allowed when not required`
 
@@ -112,16 +100,6 @@ inline description of application profile
 | ------------------------- | ------------------------- |
 | **Additional properties** | Any type allowed          |
 | **Defined in**            | [Standard](./Standard.md) |
-
-### <a name="conformsTo_anyOf_i2"></a>Property `CatalogRecord > conformsTo > anyOf > Link`
-
-**Title:** Link
-
-reference iri of application profile
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="description"></a>Property `CatalogRecord > description`
 

--- a/jsonschema/docs/Concept.md
+++ b/jsonschema/docs/Concept.md
@@ -36,7 +36,7 @@ The value of the concept, expressed as a string. This is only used when the conc
 | - [altLabelMap](#anyOf_i1_altLabelMap )     | null or object     | Language map for alternate label. E.g. {'es': 'spanish words', 'fr': 'french words'} |
 | - [definition](#anyOf_i1_definition )       | null or string     | definition                                                                           |
 | - [definitionMap](#anyOf_i1_definitionMap ) | null or object     | Language map for definition. E.g. {'es': 'spanish words', 'fr': 'french words'}      |
-| - [inScheme](#anyOf_i1_inScheme )           | More than one type | in scheme                                                                            |
+| - [inScheme](#anyOf_i1_inScheme )           | object             | in scheme                                                                            |
 | - [notation](#anyOf_i1_notation )           | More than one type | notation                                                                             |
 | + [prefLabel](#anyOf_i1_prefLabel )         | string             | preferred label                                                                      |
 | - [prefLabelMap](#anyOf_i1_prefLabelMap )   | null or object     | Language map for preferred label. E.g. {'es': 'spanish words', 'fr': 'french words'} |
@@ -91,33 +91,10 @@ Language map for definition. E.g. {'es': 'spanish words', 'fr': 'french words'}
 
 Concept scheme defining this concept
 
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                               |
-| -------------------------------------------- |
-| [ConceptScheme](#anyOf_i1_inScheme_anyOf_i0) |
-| [item 1](#anyOf_i1_inScheme_anyOf_i1)        |
-
-#### <a name="anyOf_i1_inScheme_anyOf_i0"></a>Property `Concept > anyOf > item 1 > inScheme > anyOf > ConceptScheme`
-
-**Title:** ConceptScheme
-
-inline description of ConceptScheme
-
 | **Type**                  | `object`                            |
 | ------------------------- | ----------------------------------- |
 | **Additional properties** | Any type allowed                    |
 | **Defined in**            | [Conceptscheme](./Conceptscheme.md) |
-
-#### <a name="anyOf_i1_inScheme_anyOf_i1"></a>Property `Concept > anyOf > item 1 > inScheme > anyOf > item 1`
-
-reference iri of ConceptScheme
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ### <a name="anyOf_i1_notation"></a>Property `Concept > anyOf > item 1 > notation`
 

--- a/jsonschema/docs/Concept.md
+++ b/jsonschema/docs/Concept.md
@@ -34,7 +34,7 @@ The value of the concept, expressed as a string. This is only used when the conc
 | - [@type](#anyOf_i1_@type )           | string             | -                 |
 | - [altLabel](#anyOf_i1_altLabel )     | null or string     | alternate label   |
 | - [definition](#anyOf_i1_definition ) | null or string     | definition        |
-| - [inScheme](#anyOf_i1_inScheme )     | More than one type | in scheme         |
+| - [inScheme](#anyOf_i1_inScheme )     | object             | in scheme         |
 | - [notation](#anyOf_i1_notation )     | More than one type | notation          |
 | + [prefLabel](#anyOf_i1_prefLabel )   | string             | preferred label   |
 

--- a/jsonschema/docs/DataService.md
+++ b/jsonschema/docs/DataService.md
@@ -13,7 +13,7 @@ A service for providing data at a URL or URLs
 | - [@id](#@id )                                             | string                  | -                            |
 | - [@type](#@type )                                         | string                  | -                            |
 | + [contactPoint](#contactPoint )                           | array                   | contact point                |
-| - [endpointDescription](#endpointDescription )             | null or array           | endpoint description         |
+| - [endpointDescription](#endpointDescription )             | null or array of string | endpoint description         |
 | + [endpointURL](#endpointURL )                             | array of string         | endpoint URL                 |
 | - [keyword](#keyword )                                     | null or array of string | keyword/tag                  |
 | - [servesDataset](#servesDataset )                         | null or array           | serves dataset               |
@@ -30,8 +30,8 @@ A service for providing data at a URL or URLs
 | - [language](#language )                                   | More than one type      | language                     |
 | - [license](#license )                                     | More than one type      | license                      |
 | - [modified](#modified )                                   | More than one type      | update/modification date     |
-| + [publisher](#publisher )                                 | More than one type      | publisher                    |
-| - [rights](#rights )                                       | null or array           | rights                       |
+| + [publisher](#publisher )                                 | object                  | publisher                    |
+| - [rights](#rights )                                       | null or array of string | rights                       |
 | - [rightsHolder](#rightsHolder )                           | null or array           | rights holder                |
 | - [spatial](#spatial )                                     | null or array           | spatial/geographic coverage  |
 | - [temporal](#temporal )                                   | null or array           | temporal coverage            |

--- a/jsonschema/docs/DataService.md
+++ b/jsonschema/docs/DataService.md
@@ -266,10 +266,10 @@ List of general standards or specifications that the Data Service endpoints impl
 
 Information about a particular standard that another item conforms to
 
-| **Type**                  | `object`                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                            |
-| **Same definition as**    | [Standard](#servesDataset_items_sample_items_accessService_items_anyOf_i0_conformsTo_items) |
+| **Type**                  | `object`                                                                           |
+| ------------------------- | ---------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                   |
+| **Same definition as**    | [Standard](#servesDataset_items_sample_items_accessService_items_conformsTo_items) |
 
 ## <a name="created"></a>Property `DataService > created`
 
@@ -359,10 +359,10 @@ List of agents primarily responsible for producing the Data Service
 
 An entity that could be involved with a resource
 
-| **Type**                  | `object`                                                                              |
-| ------------------------- | ------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                      |
-| **Same definition as**    | [Agent](#servesDataset_items_sample_items_accessService_items_anyOf_i0_creator_items) |
+| **Type**                  | `object`                                                                     |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                             |
+| **Same definition as**    | [Agent](#servesDataset_items_sample_items_accessService_items_creator_items) |
 
 ## <a name="description"></a>Property `DataService > description`
 
@@ -664,10 +664,10 @@ A geographic region that is covered by the Data Service
 
 Information about a specific geographic location
 
-| **Type**                  | `object`                                                                                 |
-| ------------------------- | ---------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                         |
-| **Same definition as**    | [Location](#servesDataset_items_sample_items_accessService_items_anyOf_i0_spatial_items) |
+| **Type**                  | `object`                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                |
+| **Same definition as**    | [Location](#servesDataset_items_sample_items_accessService_items_spatial_items) |
 
 ## <a name="temporal"></a>Property `DataService > temporal`
 
@@ -688,10 +688,10 @@ A list of temporal periods that the DataService covers
 
 Information about a specific time period with a start- and/or end-time
 
-| **Type**                  | `object`                                                                                      |
-| ------------------------- | --------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                              |
-| **Same definition as**    | [PeriodOfTime](#servesDataset_items_sample_items_accessService_items_anyOf_i0_temporal_items) |
+| **Type**                  | `object`                                                                             |
+| ------------------------- | ------------------------------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                                                     |
+| **Same definition as**    | [PeriodOfTime](#servesDataset_items_sample_items_accessService_items_temporal_items) |
 
 ## <a name="title"></a>Property `DataService > title`
 
@@ -753,10 +753,10 @@ Refers to the performed quality measurements
 
 A single measurement of one metric
 
-| **Type**                  | `object`                                                                                                         |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                 |
-| **Same definition as**    | [QualityMeasurement](#servesDataset_items_sample_items_accessService_items_anyOf_i0_hasQualityMeasurement_items) |
+| **Type**                  | `object`                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                        |
+| **Same definition as**    | [QualityMeasurement](#servesDataset_items_sample_items_accessService_items_hasQualityMeasurement_items) |
 
 ## <a name="qualifiedAttribution"></a>Property `DataService > qualifiedAttribution`
 
@@ -777,10 +777,10 @@ List of agents having some form of responsibility for the Data Service
 
 An attribution that an agent plays some role
 
-| **Type**                  | `object`                                                                                                 |
-| ------------------------- | -------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                         |
-| **Same definition as**    | [Attribution](#servesDataset_items_sample_items_accessService_items_anyOf_i0_qualifiedAttribution_items) |
+| **Type**                  | `object`                                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                |
+| **Same definition as**    | [Attribution](#servesDataset_items_sample_items_accessService_items_qualifiedAttribution_items) |
 
 ## <a name="wasUsedBy"></a>Property `DataService > wasUsedBy`
 
@@ -801,8 +801,8 @@ List of activities that used the Data Service
 
 An activity which a resource could be related to
 
-| **Type**                  | `object`                                                                                   |
-| ------------------------- | ------------------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                                           |
-| **Same definition as**    | [Activity](#servesDataset_items_sample_items_accessService_items_anyOf_i0_wasUsedBy_items) |
+| **Type**                  | `object`                                                                          |
+| ------------------------- | --------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                  |
+| **Same definition as**    | [Activity](#servesDataset_items_sample_items_accessService_items_wasUsedBy_items) |
 

--- a/jsonschema/docs/DataService.md
+++ b/jsonschema/docs/DataService.md
@@ -13,7 +13,7 @@ A service for providing data at a URL or URLs
 | - [@id](#@id )                                             | string                  | -                                                                                    |
 | - [@type](#@type )                                         | string                  | -                                                                                    |
 | + [contactPoint](#contactPoint )                           | array                   | contact point                                                                        |
-| - [endpointDescription](#endpointDescription )             | null or array           | endpoint description                                                                 |
+| - [endpointDescription](#endpointDescription )             | null or array of string | endpoint description                                                                 |
 | + [endpointURL](#endpointURL )                             | array of string         | endpoint URL                                                                         |
 | - [keyword](#keyword )                                     | null or array of string | keyword/tag                                                                          |
 | - [keywordMap](#keywordMap )                               | null or object          | Language map for keyword. E.g. {'es': 'spanish words', 'fr': 'french words'}         |
@@ -32,8 +32,8 @@ A service for providing data at a URL or URLs
 | - [language](#language )                                   | More than one type      | language                                                                             |
 | - [license](#license )                                     | More than one type      | license                                                                              |
 | - [modified](#modified )                                   | More than one type      | update/modification date                                                             |
-| + [publisher](#publisher )                                 | More than one type      | publisher                                                                            |
-| - [rights](#rights )                                       | null or array           | rights                                                                               |
+| + [publisher](#publisher )                                 | object                  | publisher                                                                            |
+| - [rights](#rights )                                       | null or array of string | rights                                                                               |
 | - [rightsHolder](#rightsHolder )                           | null or array           | rights holder                                                                        |
 | - [spatial](#spatial )                                     | null or array           | spatial/geographic coverage                                                          |
 | - [temporal](#temporal )                                   | null or array           | temporal coverage                                                                    |
@@ -66,43 +66,20 @@ Contact information that can be used for sending comments about the Data Service
 | ------------ | ------- |
 | **Required** | Yes     |
 
-| Each item of this array must be            | Description |
-| ------------------------------------------ | ----------- |
-| [Kind object or link](#contactPoint_items) | -           |
+| Each item of this array must be | Description                                     |
+| ------------------------------- | ----------------------------------------------- |
+| [Kind](#contactPoint_items)     | Contact information for an individual or entity |
 
-### <a name="contactPoint_items"></a>DataService > contactPoint > Kind object or link
-
-**Title:** Kind object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                       |
-| ------------------------------------ |
-| [Kind](#contactPoint_items_anyOf_i0) |
-| [Link](#contactPoint_items_anyOf_i1) |
-
-#### <a name="contactPoint_items_anyOf_i0"></a>Property `DataService > contactPoint > Kind object or link > anyOf > Kind`
+### <a name="contactPoint_items"></a>DataService > contactPoint > Kind
 
 **Title:** Kind
 
-inline description of Kind
+Contact information for an individual or entity
 
 | **Type**                  | `object`          |
 | ------------------------- | ----------------- |
 | **Additional properties** | Any type allowed  |
 | **Defined in**            | [Kind](./Kind.md) |
-
-#### <a name="contactPoint_items_anyOf_i1"></a>Property `DataService > contactPoint > Kind object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Kind
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="endpointDescription"></a>Property `DataService > endpointDescription`
 
@@ -110,8 +87,8 @@ reference iri of Kind
 
 A list of descriptions of the services available via the end-points, including their operations, parameters etc
 
-| **Type** | `null or array` |
-| -------- | --------------- |
+| **Type** | `null or array of string` |
+| -------- | ------------------------- |
 
 | Each item of this array must be                         | Description |
 | ------------------------------------------------------- | ----------- |
@@ -119,31 +96,8 @@ A list of descriptions of the services available via the end-points, including t
 
 ### <a name="endpointDescription_items"></a>DataService > endpointDescription > endpointDescription items
 
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                |
-| --------------------------------------------- |
-| [item 0](#endpointDescription_items_anyOf_i0) |
-| [Link](#endpointDescription_items_anyOf_i1)   |
-
-#### <a name="endpointDescription_items_anyOf_i0"></a>Property `DataService > endpointDescription > endpointDescription items > anyOf > item 0`
-
-An in-line description of the endpoint description
-
 | **Type** | `string` |
 | -------- | -------- |
-
-#### <a name="endpointDescription_items_anyOf_i1"></a>Property `DataService > endpointDescription > endpointDescription items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the endpoint description
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="endpointURL"></a>Property `DataService > endpointURL`
 
@@ -209,43 +163,20 @@ List of datasets that are served by this data service
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [Dataset object or link](#servesDataset_items) | -           |
+| Each item of this array must be | Description                     |
+| ------------------------------- | ------------------------------- |
+| [Dataset](#servesDataset_items) | Information about a set of data |
 
-### <a name="servesDataset_items"></a>DataService > servesDataset > Dataset object or link
-
-**Title:** Dataset object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                           |
-| ---------------------------------------- |
-| [Dataset](#servesDataset_items_anyOf_i0) |
-| [Link](#servesDataset_items_anyOf_i1)    |
-
-#### <a name="servesDataset_items_anyOf_i0"></a>Property `DataService > servesDataset > Dataset object or link > anyOf > Dataset`
+### <a name="servesDataset_items"></a>DataService > servesDataset > Dataset
 
 **Title:** Dataset
 
-inline description of Dataset
+Information about a set of data
 
 | **Type**                  | `object`                |
 | ------------------------- | ----------------------- |
 | **Additional properties** | Any type allowed        |
 | **Defined in**            | [Dataset](./Dataset.md) |
-
-#### <a name="servesDataset_items_anyOf_i1"></a>Property `DataService > servesDataset > Dataset object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Dataset
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="spatialResolutionInMeters"></a>Property `DataService > spatialResolutionInMeters`
 
@@ -274,43 +205,20 @@ A list of themes of the Data Service. A Data Service may be associated with mult
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be | Description |
-| ------------------------------- | ----------- |
-| [Theme or link](#theme_items)   | -           |
+| Each item of this array must be | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [Concept](#theme_items)         | A labeled value from an optionally specified concept scheme |
 
-### <a name="theme_items"></a>DataService > theme > Theme or link
-
-**Title:** Theme or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                   |
-| -------------------------------- |
-| [Concept](#theme_items_anyOf_i0) |
-| [Link](#theme_items_anyOf_i1)    |
-
-#### <a name="theme_items_anyOf_i0"></a>Property `DataService > theme > Theme or link > anyOf > Concept`
+### <a name="theme_items"></a>DataService > theme > Concept
 
 **Title:** Concept
 
-inline description of Concept
+A labeled value from an optionally specified concept scheme
 
-| **Type**                  | More than one type                                                                              |
-| ------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                |
-| **Same definition as**    | [Concept](#servesDataset_items_anyOf_i0_sample_items_anyOf_i0_representationTechnique_anyOf_i1) |
-
-#### <a name="theme_items_anyOf_i1"></a>Property `DataService > theme > Theme or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                                            |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                              |
+| **Same definition as**    | [Concept](#servesDataset_items_sample_items_representationTechnique_anyOf_i1) |
 
 ## <a name="accessRights"></a>Property `DataService > accessRights`
 
@@ -326,7 +234,6 @@ Information that indicates whether the Data Service is open data, has access res
 | -------------------------------- |
 | [item 0](#accessRights_anyOf_i0) |
 | [item 1](#accessRights_anyOf_i1) |
-| [Link](#accessRights_anyOf_i2)   |
 
 ### <a name="accessRights_anyOf_i0"></a>Property `DataService > accessRights > anyOf > item 0`
 
@@ -340,16 +247,6 @@ Text description of the access rights
 | **Type** | `string` |
 | -------- | -------- |
 
-### <a name="accessRights_anyOf_i2"></a>Property `DataService > accessRights > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the access rights
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
 ## <a name="conformsTo"></a>Property `DataService > conformsTo`
 
 **Title:** conforms to
@@ -359,43 +256,20 @@ List of general standards or specifications that the Data Service endpoints impl
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be              | Description |
-| -------------------------------------------- | ----------- |
-| [Standard object or link](#conformsTo_items) | -           |
+| Each item of this array must be | Description                                                           |
+| ------------------------------- | --------------------------------------------------------------------- |
+| [Standard](#conformsTo_items)   | Information about a particular standard that another item conforms to |
 
-### <a name="conformsTo_items"></a>DataService > conformsTo > Standard object or link
-
-**Title:** Standard object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                         |
-| -------------------------------------- |
-| [Standard](#conformsTo_items_anyOf_i0) |
-| [Link](#conformsTo_items_anyOf_i1)     |
-
-#### <a name="conformsTo_items_anyOf_i0"></a>Property `DataService > conformsTo > Standard object or link > anyOf > Standard`
+### <a name="conformsTo_items"></a>DataService > conformsTo > Standard
 
 **Title:** Standard
 
-inline description of Standard
+Information about a particular standard that another item conforms to
 
-| **Type**                  | `object`                                                                                                               |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                       |
-| **Same definition as**    | [Standard](#servesDataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_conformsTo_items_anyOf_i0) |
-
-#### <a name="conformsTo_items_anyOf_i1"></a>Property `DataService > conformsTo > Standard object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Standard
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                            |
+| **Same definition as**    | [Standard](#servesDataset_items_sample_items_accessService_items_anyOf_i0_conformsTo_items) |
 
 ## <a name="created"></a>Property `DataService > created`
 
@@ -475,43 +349,20 @@ List of agents primarily responsible for producing the Data Service
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be        | Description |
-| -------------------------------------- | ----------- |
-| [Agent object or link](#creator_items) | -           |
+| Each item of this array must be | Description                                      |
+| ------------------------------- | ------------------------------------------------ |
+| [Agent](#creator_items)         | An entity that could be involved with a resource |
 
-### <a name="creator_items"></a>DataService > creator > Agent object or link
-
-**Title:** Agent object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                   |
-| -------------------------------- |
-| [Agent](#creator_items_anyOf_i0) |
-| [Link](#creator_items_anyOf_i1)  |
-
-#### <a name="creator_items_anyOf_i0"></a>Property `DataService > creator > Agent object or link > anyOf > Agent`
+### <a name="creator_items"></a>DataService > creator > Agent
 
 **Title:** Agent
 
-inline description of Agent
+An entity that could be involved with a resource
 
-| **Type**                  | `object`                                                                                                         |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                 |
-| **Same definition as**    | [Agent](#servesDataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_creator_items_anyOf_i0) |
-
-#### <a name="creator_items_anyOf_i1"></a>Property `DataService > creator > Agent object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Agent
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                      |
+| **Same definition as**    | [Agent](#servesDataset_items_sample_items_accessService_items_anyOf_i0_creator_items) |
 
 ## <a name="description"></a>Property `DataService > description`
 
@@ -543,7 +394,6 @@ The unique identifier for the Data Service, e.g. the URI or other unique identif
 | ---------------------------------- |
 | [item 0](#identifier_anyOf_i0)     |
 | [Identifier](#identifier_anyOf_i1) |
-| [Link](#identifier_anyOf_i2)       |
 
 ### <a name="identifier_anyOf_i0"></a>Property `DataService > identifier > anyOf > item 0`
 
@@ -556,20 +406,10 @@ The unique identifier for the Data Service, e.g. the URI or other unique identif
 
 inline description of Identifier
 
-| **Type**                  | More than one type                                                         |
-| ------------------------- | -------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                           |
-| **Same definition as**    | [Identifier](#servesDataset_items_anyOf_i0_otherIdentifier_items_anyOf_i0) |
-
-### <a name="identifier_anyOf_i2"></a>Property `DataService > identifier > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                       |
+| ------------------------- | -------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                         |
+| **Same definition as**    | [Identifier](#servesDataset_items_otherIdentifier_items) |
 
 ## <a name="otherIdentifier"></a>Property `DataService > otherIdentifier`
 
@@ -580,41 +420,20 @@ A list of identifiers for the Data Service besides the main identifier, e.g. the
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                 | Description |
-| ----------------------------------------------- | ----------- |
-| [otherIdentifier items](#otherIdentifier_items) | -           |
+| Each item of this array must be      | Description                                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------- |
+| [Identifier](#otherIdentifier_items) | A unique identifier and optionally it's scheme and other relevant information |
 
-### <a name="otherIdentifier_items"></a>DataService > otherIdentifier > otherIdentifier items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                |
-| --------------------------------------------- |
-| [Identifier](#otherIdentifier_items_anyOf_i0) |
-| [Link](#otherIdentifier_items_anyOf_i1)       |
-
-#### <a name="otherIdentifier_items_anyOf_i0"></a>Property `DataService > otherIdentifier > otherIdentifier items > anyOf > Identifier`
+### <a name="otherIdentifier_items"></a>DataService > otherIdentifier > Identifier
 
 **Title:** Identifier
 
-inline description of Identifier
+A unique identifier and optionally it's scheme and other relevant information
 
-| **Type**                  | More than one type                                                         |
-| ------------------------- | -------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                           |
-| **Same definition as**    | [Identifier](#servesDataset_items_anyOf_i0_otherIdentifier_items_anyOf_i0) |
-
-#### <a name="otherIdentifier_items_anyOf_i1"></a>Property `DataService > otherIdentifier > otherIdentifier items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                       |
+| ------------------------- | -------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                         |
+| **Same definition as**    | [Identifier](#servesDataset_items_otherIdentifier_items) |
 
 ## <a name="language"></a>Property `DataService > language`
 
@@ -686,7 +505,6 @@ The license under which the Data Service is made available; see https://resource
 | --------------------------------------------------- |
 | [Null allowed when not required](#license_anyOf_i0) |
 | [item 1](#license_anyOf_i1)                         |
-| [Link](#license_anyOf_i2)                           |
 
 ### <a name="license_anyOf_i0"></a>Property `DataService > license > anyOf > Null allowed when not required`
 
@@ -701,16 +519,6 @@ Full text of the license
 
 | **Type** | `string` |
 | -------- | -------- |
-
-### <a name="license_anyOf_i2"></a>Property `DataService > license > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the license
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="modified"></a>Property `DataService > modified`
 
@@ -789,36 +597,11 @@ A year and month in YYYY-MM format
 
 An entity (organization) responsible for making the Data Service available
 
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Required**              | Yes                |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)               |
-| ---------------------------- |
-| [Agent](#publisher_anyOf_i0) |
-| [Link](#publisher_anyOf_i1)  |
-
-### <a name="publisher_anyOf_i0"></a>Property `DataService > publisher > anyOf > Agent`
-
-**Title:** Agent
-
-inline description of Agent
-
-| **Type**                  | `object`                                                                                                         |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                 |
-| **Same definition as**    | [Agent](#servesDataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_creator_items_anyOf_i0) |
-
-### <a name="publisher_anyOf_i1"></a>Property `DataService > publisher > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Agent
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`            |
+| ------------------------- | ------------------- |
+| **Required**              | Yes                 |
+| **Additional properties** | Any type allowed    |
+| **Defined in**            | [Agent](./Agent.md) |
 
 ## <a name="rights"></a>Property `DataService > rights`
 
@@ -826,42 +609,17 @@ reference iri of Agent
 
 A list of statements concerning all rights for the Data Service that may not be addressed by license or accessRights, such as copyright statements, statements about the intellectual property rights (IPR), or information regarding access or restrictions based on privacy, security, or other policies
 
-| **Type** | `null or array` |
-| -------- | --------------- |
+| **Type** | `null or array of string` |
+| -------- | ------------------------- |
 
-| Each item of this array must be                 | Description |
-| ----------------------------------------------- | ----------- |
-| [RightsStatement object or link](#rights_items) | -           |
+| Each item of this array must be | Description |
+| ------------------------------- | ----------- |
+| [rights items](#rights_items)   | -           |
 
-### <a name="rights_items"></a>DataService > rights > RightsStatement object or link
-
-**Title:** RightsStatement object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                   |
-| -------------------------------- |
-| [item 0](#rights_items_anyOf_i0) |
-| [Link](#rights_items_anyOf_i1)   |
-
-#### <a name="rights_items_anyOf_i0"></a>Property `DataService > rights > RightsStatement object or link > anyOf > item 0`
-
-Full text of a statement of rights
+### <a name="rights_items"></a>DataService > rights > rights items
 
 | **Type** | `string` |
 | -------- | -------- |
-
-#### <a name="rights_items_anyOf_i1"></a>Property `DataService > rights > RightsStatement object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of a statement of rights
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="rightsHolder"></a>Property `DataService > rightsHolder`
 
@@ -872,43 +630,20 @@ A list of Agents (organizations) holding rights on the Data Service
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                    | Description |
-| -------------------------------------------------- | ----------- |
-| [Organization object or link](#rightsHolder_items) | -           |
+| Each item of this array must be     | Description                                                                         |
+| ----------------------------------- | ----------------------------------------------------------------------------------- |
+| [Organization](#rightsHolder_items) | Information about an organization, including other organizations that it is part of |
 
-### <a name="rightsHolder_items"></a>DataService > rightsHolder > Organization object or link
-
-**Title:** Organization object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                               |
-| -------------------------------------------- |
-| [Organization](#rightsHolder_items_anyOf_i0) |
-| [Link](#rightsHolder_items_anyOf_i1)         |
-
-#### <a name="rightsHolder_items_anyOf_i0"></a>Property `DataService > rightsHolder > Organization object or link > anyOf > Organization`
+### <a name="rightsHolder_items"></a>DataService > rightsHolder > Organization
 
 **Title:** Organization
 
-inline description of Organization
+Information about an organization, including other organizations that it is part of
 
-| **Type**                  | `object`                                                                                               |
-| ------------------------- | ------------------------------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                                                       |
-| **Same definition as**    | [Organization](#servesDataset_items_anyOf_i0_otherIdentifier_items_anyOf_i0_anyOf_i1_creator_anyOf_i1) |
-
-#### <a name="rightsHolder_items_anyOf_i1"></a>Property `DataService > rightsHolder > Organization object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Organization
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                             |
+| ------------------------- | ------------------------------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                                                     |
+| **Same definition as**    | [Organization](#servesDataset_items_otherIdentifier_items_anyOf_i1_creator_anyOf_i1) |
 
 ## <a name="spatial"></a>Property `DataService > spatial`
 
@@ -919,43 +654,20 @@ A geographic region that is covered by the Data Service
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be           | Description |
-| ----------------------------------------- | ----------- |
-| [Location object or link](#spatial_items) | -           |
+| Each item of this array must be | Description                                      |
+| ------------------------------- | ------------------------------------------------ |
+| [Location](#spatial_items)      | Information about a specific geographic location |
 
-### <a name="spatial_items"></a>DataService > spatial > Location object or link
-
-**Title:** Location object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Location](#spatial_items_anyOf_i0) |
-| [Link](#spatial_items_anyOf_i1)     |
-
-#### <a name="spatial_items_anyOf_i0"></a>Property `DataService > spatial > Location object or link > anyOf > Location`
+### <a name="spatial_items"></a>DataService > spatial > Location
 
 **Title:** Location
 
-inline description of Location
+Information about a specific geographic location
 
-| **Type**                  | `object`                                                                                                            |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                    |
-| **Same definition as**    | [Location](#servesDataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_spatial_items_anyOf_i0) |
-
-#### <a name="spatial_items_anyOf_i1"></a>Property `DataService > spatial > Location object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Location
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                 |
+| ------------------------- | ---------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                         |
+| **Same definition as**    | [Location](#servesDataset_items_sample_items_accessService_items_anyOf_i0_spatial_items) |
 
 ## <a name="temporal"></a>Property `DataService > temporal`
 
@@ -966,43 +678,20 @@ A list of temporal periods that the DataService covers
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [PeriodOfTime object or link](#temporal_items) | -           |
+| Each item of this array must be | Description                                                            |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| [PeriodOfTime](#temporal_items) | Information about a specific time period with a start- and/or end-time |
 
-### <a name="temporal_items"></a>DataService > temporal > PeriodOfTime object or link
-
-**Title:** PeriodOfTime object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                           |
-| ---------------------------------------- |
-| [PeriodOfTime](#temporal_items_anyOf_i0) |
-| [Link](#temporal_items_anyOf_i1)         |
-
-#### <a name="temporal_items_anyOf_i0"></a>Property `DataService > temporal > PeriodOfTime object or link > anyOf > PeriodOfTime`
+### <a name="temporal_items"></a>DataService > temporal > PeriodOfTime
 
 **Title:** PeriodOfTime
 
-inline description of PeriodOfTime
+Information about a specific time period with a start- and/or end-time
 
-| **Type**                  | `object`                                                                                                                 |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                                                                         |
-| **Same definition as**    | [PeriodOfTime](#servesDataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_temporal_items_anyOf_i0) |
-
-#### <a name="temporal_items_anyOf_i1"></a>Property `DataService > temporal > PeriodOfTime object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of PeriodOfTime
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                      |
+| ------------------------- | --------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                              |
+| **Same definition as**    | [PeriodOfTime](#servesDataset_items_sample_items_accessService_items_anyOf_i0_temporal_items) |
 
 ## <a name="title"></a>Property `DataService > title`
 
@@ -1030,43 +719,20 @@ List of categories for the Data Service
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be     | Description |
-| ----------------------------------- | ----------- |
-| [Category or link](#category_items) | -           |
+| Each item of this array must be | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [Concept](#category_items)      | A labeled value from an optionally specified concept scheme |
 
-### <a name="category_items"></a>DataService > category > Category or link
-
-**Title:** Category or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Concept](#category_items_anyOf_i0) |
-| [Link](#category_items_anyOf_i1)    |
-
-#### <a name="category_items_anyOf_i0"></a>Property `DataService > category > Category or link > anyOf > Concept`
+### <a name="category_items"></a>DataService > category > Concept
 
 **Title:** Concept
 
-inline description of Concept
+A labeled value from an optionally specified concept scheme
 
-| **Type**                  | More than one type                                                                              |
-| ------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                |
-| **Same definition as**    | [Concept](#servesDataset_items_anyOf_i0_sample_items_anyOf_i0_representationTechnique_anyOf_i1) |
-
-#### <a name="category_items_anyOf_i1"></a>Property `DataService > category > Category or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                                            |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                              |
+| **Same definition as**    | [Concept](#servesDataset_items_sample_items_representationTechnique_anyOf_i1) |
 
 ## <a name="hasQualityMeasurement"></a>Property `DataService > hasQualityMeasurement`
 
@@ -1077,43 +743,20 @@ Refers to the performed quality measurements
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                                   | Description |
-| ----------------------------------------------------------------- | ----------- |
-| [QualityMeasurement object or link](#hasQualityMeasurement_items) | -           |
+| Each item of this array must be                    | Description                        |
+| -------------------------------------------------- | ---------------------------------- |
+| [QualityMeasurement](#hasQualityMeasurement_items) | A single measurement of one metric |
 
-### <a name="hasQualityMeasurement_items"></a>DataService > hasQualityMeasurement > QualityMeasurement object or link
-
-**Title:** QualityMeasurement object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                              |
-| ----------------------------------------------------------- |
-| [QualityMeasurement](#hasQualityMeasurement_items_anyOf_i0) |
-| [Link](#hasQualityMeasurement_items_anyOf_i1)               |
-
-#### <a name="hasQualityMeasurement_items_anyOf_i0"></a>Property `DataService > hasQualityMeasurement > QualityMeasurement object or link > anyOf > QualityMeasurement`
+### <a name="hasQualityMeasurement_items"></a>DataService > hasQualityMeasurement > QualityMeasurement
 
 **Title:** QualityMeasurement
 
-inline description of QualityMeasurement
+A single measurement of one metric
 
-| **Type**                  | `object`                                                                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                                            |
-| **Same definition as**    | [QualityMeasurement](#servesDataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_hasQualityMeasurement_items_anyOf_i0) |
-
-#### <a name="hasQualityMeasurement_items_anyOf_i1"></a>Property `DataService > hasQualityMeasurement > QualityMeasurement object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of QualityMeasurement
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                                         |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                                 |
+| **Same definition as**    | [QualityMeasurement](#servesDataset_items_sample_items_accessService_items_anyOf_i0_hasQualityMeasurement_items) |
 
 ## <a name="qualifiedAttribution"></a>Property `DataService > qualifiedAttribution`
 
@@ -1124,43 +767,20 @@ List of agents having some form of responsibility for the Data Service
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                           | Description |
-| --------------------------------------------------------- | ----------- |
-| [Attribution object or link](#qualifiedAttribution_items) | -           |
+| Each item of this array must be            | Description                                  |
+| ------------------------------------------ | -------------------------------------------- |
+| [Attribution](#qualifiedAttribution_items) | An attribution that an agent plays some role |
 
-### <a name="qualifiedAttribution_items"></a>DataService > qualifiedAttribution > Attribution object or link
-
-**Title:** Attribution object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                      |
-| --------------------------------------------------- |
-| [Attribution](#qualifiedAttribution_items_anyOf_i0) |
-| [Link](#qualifiedAttribution_items_anyOf_i1)        |
-
-#### <a name="qualifiedAttribution_items_anyOf_i0"></a>Property `DataService > qualifiedAttribution > Attribution object or link > anyOf > Attribution`
+### <a name="qualifiedAttribution_items"></a>DataService > qualifiedAttribution > Attribution
 
 **Title:** Attribution
 
-inline description of Attribution
+An attribution that an agent plays some role
 
-| **Type**                  | `object`                                                                                                                            |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                                    |
-| **Same definition as**    | [Attribution](#servesDataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_qualifiedAttribution_items_anyOf_i0) |
-
-#### <a name="qualifiedAttribution_items_anyOf_i1"></a>Property `DataService > qualifiedAttribution > Attribution object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Attribution
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                                 |
+| ------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                         |
+| **Same definition as**    | [Attribution](#servesDataset_items_sample_items_accessService_items_anyOf_i0_qualifiedAttribution_items) |
 
 ## <a name="wasUsedBy"></a>Property `DataService > wasUsedBy`
 
@@ -1171,41 +791,18 @@ List of activities that used the Data Service
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be             | Description |
-| ------------------------------------------- | ----------- |
-| [Activity object or link](#wasUsedBy_items) | -           |
+| Each item of this array must be | Description                                      |
+| ------------------------------- | ------------------------------------------------ |
+| [Activity](#wasUsedBy_items)    | An activity which a resource could be related to |
 
-### <a name="wasUsedBy_items"></a>DataService > wasUsedBy > Activity object or link
-
-**Title:** Activity object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                        |
-| ------------------------------------- |
-| [Activity](#wasUsedBy_items_anyOf_i0) |
-| [Link](#wasUsedBy_items_anyOf_i1)     |
-
-#### <a name="wasUsedBy_items_anyOf_i0"></a>Property `DataService > wasUsedBy > Activity object or link > anyOf > Activity`
+### <a name="wasUsedBy_items"></a>DataService > wasUsedBy > Activity
 
 **Title:** Activity
 
-inline description of Activity
+An activity which a resource could be related to
 
-| **Type**                  | `object`                                                                                                              |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                      |
-| **Same definition as**    | [Activity](#servesDataset_items_anyOf_i0_sample_items_anyOf_i0_accessService_items_anyOf_i0_wasUsedBy_items_anyOf_i0) |
-
-#### <a name="wasUsedBy_items_anyOf_i1"></a>Property `DataService > wasUsedBy > Activity object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Activity
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                   |
+| ------------------------- | ------------------------------------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                                                           |
+| **Same definition as**    | [Activity](#servesDataset_items_sample_items_accessService_items_anyOf_i0_wasUsedBy_items) |
 

--- a/jsonschema/docs/Dataset.md
+++ b/jsonschema/docs/Dataset.md
@@ -51,11 +51,11 @@ Information about a set of data
 | - [issued](#issued )                                       | More than one type      | release date                                                                        |
 | - [language](#language )                                   | More than one type      | language                                                                            |
 | - [modified](#modified )                                   | More than one type      | last modified                                                                       |
-| - [provenance](#provenance )                               | null or array           | provenance                                                                          |
-| + [publisher](#publisher )                                 | More than one type      | publisher                                                                           |
+| - [provenance](#provenance )                               | null or array of string | provenance                                                                          |
+| + [publisher](#publisher )                                 | object                  | publisher                                                                           |
 | - [relation](#relation )                                   | null or array of string | related resource                                                                    |
 | - [replaces](#replaces )                                   | null or array           | replaces                                                                            |
-| - [rights](#rights )                                       | null or array           | rights                                                                              |
+| - [rights](#rights )                                       | null or array of string | rights                                                                              |
 | - [rightsHolder](#rightsHolder )                           | null or array           | rights holder                                                                       |
 | - [source](#source )                                       | null or array           | data source                                                                         |
 | - [spatial](#spatial )                                     | More than one type      | spatial/geographic coverage                                                         |
@@ -95,41 +95,20 @@ A list of identifiers for the Dataset besides the main identifier, e.g. the URI 
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                 | Description |
-| ----------------------------------------------- | ----------- |
-| [otherIdentifier items](#otherIdentifier_items) | -           |
+| Each item of this array must be      | Description                                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------- |
+| [Identifier](#otherIdentifier_items) | A unique identifier and optionally it's scheme and other relevant information |
 
-### <a name="otherIdentifier_items"></a>Dataset > otherIdentifier > otherIdentifier items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                |
-| --------------------------------------------- |
-| [Identifier](#otherIdentifier_items_anyOf_i0) |
-| [Link](#otherIdentifier_items_anyOf_i1)       |
-
-#### <a name="otherIdentifier_items_anyOf_i0"></a>Property `Dataset > otherIdentifier > otherIdentifier items > anyOf > Identifier`
+### <a name="otherIdentifier_items"></a>Dataset > otherIdentifier > Identifier
 
 **Title:** Identifier
 
-inline description of Identifier
+A unique identifier and optionally it's scheme and other relevant information
 
 | **Type**                  | More than one type            |
 | ------------------------- | ----------------------------- |
 | **Additional properties** | Any type allowed              |
 | **Defined in**            | [Identifier](./Identifier.md) |
-
-#### <a name="otherIdentifier_items_anyOf_i1"></a>Property `Dataset > otherIdentifier > otherIdentifier items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="sample"></a>Property `Dataset > sample`
 
@@ -140,43 +119,20 @@ List of links to samples of a Dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be              | Description |
-| -------------------------------------------- | ----------- |
-| [Distribution object or link](#sample_items) | -           |
+| Each item of this array must be | Description                         |
+| ------------------------------- | ----------------------------------- |
+| [Distribution](#sample_items)   | A file that distributes the dataset |
 
-### <a name="sample_items"></a>Dataset > sample > Distribution object or link
-
-**Title:** Distribution object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                         |
-| -------------------------------------- |
-| [Distribution](#sample_items_anyOf_i0) |
-| [Link](#sample_items_anyOf_i1)         |
-
-#### <a name="sample_items_anyOf_i0"></a>Property `Dataset > sample > Distribution object or link > anyOf > Distribution`
+### <a name="sample_items"></a>Dataset > sample > Distribution
 
 **Title:** Distribution
 
-inline description of Distribution
+A file that distributes the dataset
 
 | **Type**                  | `object`                          |
 | ------------------------- | --------------------------------- |
 | **Additional properties** | Any type allowed                  |
 | **Defined in**            | [Distribution](./Distribution.md) |
-
-#### <a name="sample_items_anyOf_i1"></a>Property `Dataset > sample > Distribution object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Distribution
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="status"></a>Property `Dataset > status`
 
@@ -192,7 +148,6 @@ The status of the dataset  in the context of maturity lifecycle
 | -------------------------------------------------- |
 | [Null allowed when not required](#status_anyOf_i0) |
 | [Concept](#status_anyOf_i1)                        |
-| [Link](#status_anyOf_i2)                           |
 
 ### <a name="status_anyOf_i0"></a>Property `Dataset > status > anyOf > Null allowed when not required`
 
@@ -207,20 +162,10 @@ The status of the dataset  in the context of maturity lifecycle
 
 inline description of Concept
 
-| **Type**                  | More than one type                                                 |
-| ------------------------- | ------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                   |
-| **Same definition as**    | [Concept](#sample_items_anyOf_i0_representationTechnique_anyOf_i1) |
-
-### <a name="status_anyOf_i2"></a>Property `Dataset > status > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                        |
+| ------------------------- | --------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                          |
+| **Same definition as**    | [Concept](#sample_items_representationTechnique_anyOf_i1) |
 
 ## <a name="supportedSchema"></a>Property `Dataset > supportedSchema`
 
@@ -236,7 +181,6 @@ supported schema for this dataset
 | ----------------------------------------------------------- |
 | [Null allowed when not required](#supportedSchema_anyOf_i0) |
 | [Dataset](#supportedSchema_anyOf_i1)                        |
-| [Link](#supportedSchema_anyOf_i2)                           |
 
 ### <a name="supportedSchema_anyOf_i0"></a>Property `Dataset > supportedSchema > anyOf > Null allowed when not required`
 
@@ -251,20 +195,10 @@ supported schema for this dataset
 
 inline description of the supported schema
 
-| **Type**                  | `object`                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                            |
-| **Same definition as**    | [Dataset](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0) |
-
-### <a name="supportedSchema_anyOf_i2"></a>Property `Dataset > supportedSchema > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the supported schema
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                          |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
 
 ## <a name="versionNotes"></a>Property `Dataset > versionNotes`
 
@@ -289,8 +223,7 @@ A single contact point or list of contact information that can be used for sendi
 | Any of(Option)                             |
 | ------------------------------------------ |
 | [Kind](#contactPoint_anyOf_i0)             |
-| [Link](#contactPoint_anyOf_i1)             |
-| [List of contacts](#contactPoint_anyOf_i2) |
+| [List of contacts](#contactPoint_anyOf_i1) |
 
 ### <a name="contactPoint_anyOf_i0"></a>Property `Dataset > contactPoint > anyOf > Kind`
 
@@ -298,65 +231,32 @@ A single contact point or list of contact information that can be used for sendi
 
 inline description of Kind
 
-| **Type**                  | `object`                                                                                |
-| ------------------------- | --------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                        |
-| **Same definition as**    | [Kind](#sample_items_anyOf_i0_accessService_items_anyOf_i0_contactPoint_items_anyOf_i0) |
+| **Type**                  | `object`                                                              |
+| ------------------------- | --------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                      |
+| **Same definition as**    | [Kind](#sample_items_accessService_items_anyOf_i0_contactPoint_items) |
 
-### <a name="contactPoint_anyOf_i1"></a>Property `Dataset > contactPoint > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Kind
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
-### <a name="contactPoint_anyOf_i2"></a>Property `Dataset > contactPoint > anyOf > List of contacts`
+### <a name="contactPoint_anyOf_i1"></a>Property `Dataset > contactPoint > anyOf > List of contacts`
 
 **Title:** List of contacts
 
 | **Type** | `array` |
 | -------- | ------- |
 
-| Each item of this array must be                     | Description |
-| --------------------------------------------------- | ----------- |
-| [Kind object or link](#contactPoint_anyOf_i2_items) | -           |
+| Each item of this array must be      | Description                                     |
+| ------------------------------------ | ----------------------------------------------- |
+| [Kind](#contactPoint_anyOf_i1_items) | Contact information for an individual or entity |
 
-#### <a name="contactPoint_anyOf_i2_items"></a>Dataset > contactPoint > anyOf > List of contacts > Kind object or link
-
-**Title:** Kind object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                |
-| --------------------------------------------- |
-| [Kind](#contactPoint_anyOf_i2_items_anyOf_i0) |
-| [Link](#contactPoint_anyOf_i2_items_anyOf_i1) |
-
-##### <a name="contactPoint_anyOf_i2_items_anyOf_i0"></a>Property `Dataset > contactPoint > anyOf > List of contacts > Kind object or link > anyOf > Kind`
+#### <a name="contactPoint_anyOf_i1_items"></a>Dataset > contactPoint > anyOf > List of contacts > Kind
 
 **Title:** Kind
 
-inline description of Kind
+Contact information for an individual or entity
 
-| **Type**                  | `object`                                                                                |
-| ------------------------- | --------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                        |
-| **Same definition as**    | [Kind](#sample_items_anyOf_i0_accessService_items_anyOf_i0_contactPoint_items_anyOf_i0) |
-
-##### <a name="contactPoint_anyOf_i2_items_anyOf_i1"></a>Property `Dataset > contactPoint > anyOf > List of contacts > Kind object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Kind
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                              |
+| ------------------------- | --------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                      |
+| **Same definition as**    | [Kind](#sample_items_accessService_items_anyOf_i0_contactPoint_items) |
 
 ## <a name="distribution"></a>Property `Dataset > distribution`
 
@@ -367,43 +267,20 @@ List of available distributions for the Dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                    | Description |
-| -------------------------------------------------- | ----------- |
-| [Distribution object or link](#distribution_items) | -           |
+| Each item of this array must be     | Description                         |
+| ----------------------------------- | ----------------------------------- |
+| [Distribution](#distribution_items) | A file that distributes the dataset |
 
-### <a name="distribution_items"></a>Dataset > distribution > Distribution object or link
-
-**Title:** Distribution object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                               |
-| -------------------------------------------- |
-| [Distribution](#distribution_items_anyOf_i0) |
-| [Link](#distribution_items_anyOf_i1)         |
-
-#### <a name="distribution_items_anyOf_i0"></a>Property `Dataset > distribution > Distribution object or link > anyOf > Distribution`
+### <a name="distribution_items"></a>Dataset > distribution > Distribution
 
 **Title:** Distribution
 
-inline description of Distribution
+A file that distributes the dataset
 
-| **Type**                  | `object`                               |
-| ------------------------- | -------------------------------------- |
-| **Additional properties** | Any type allowed                       |
-| **Same definition as**    | [Distribution](#sample_items_anyOf_i0) |
-
-#### <a name="distribution_items_anyOf_i1"></a>Property `Dataset > distribution > Distribution object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Distribution
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                      |
+| ------------------------- | ----------------------------- |
+| **Additional properties** | Any type allowed              |
+| **Same definition as**    | [Distribution](#sample_items) |
 
 ## <a name="first"></a>Property `Dataset > first`
 
@@ -419,7 +296,6 @@ the first item of the sequence the dataset belongs to
 | ------------------------------------------------- |
 | [Null allowed when not required](#first_anyOf_i0) |
 | [Dataset](#first_anyOf_i1)                        |
-| [Link](#first_anyOf_i2)                           |
 
 ### <a name="first_anyOf_i0"></a>Property `Dataset > first > anyOf > Null allowed when not required`
 
@@ -434,20 +310,10 @@ the first item of the sequence the dataset belongs to
 
 inline description of Dataset
 
-| **Type**                  | `object`                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                            |
-| **Same definition as**    | [Dataset](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0) |
-
-### <a name="first_anyOf_i2"></a>Property `Dataset > first > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Dataset
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                          |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
 
 ## <a name="hasCurrentVersion"></a>Property `Dataset > hasCurrentVersion`
 
@@ -463,7 +329,6 @@ reference to the current (latest) version of a dataset
 | ------------------------------------------------------------- |
 | [Null allowed when not required](#hasCurrentVersion_anyOf_i0) |
 | [Dataset](#hasCurrentVersion_anyOf_i1)                        |
-| [Link](#hasCurrentVersion_anyOf_i2)                           |
 
 ### <a name="hasCurrentVersion_anyOf_i0"></a>Property `Dataset > hasCurrentVersion > anyOf > Null allowed when not required`
 
@@ -478,20 +343,10 @@ reference to the current (latest) version of a dataset
 
 inline description of Dataset
 
-| **Type**                  | `object`                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                            |
-| **Same definition as**    | [Dataset](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0) |
-
-### <a name="hasCurrentVersion_anyOf_i2"></a>Property `Dataset > hasCurrentVersion > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Dataset
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                          |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
 
 ## <a name="hasVersion"></a>Property `Dataset > hasVersion`
 
@@ -502,43 +357,20 @@ List of related Datasets that are a version, edition, or adaptation of the descr
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be             | Description |
-| ------------------------------------------- | ----------- |
-| [Dataset object or link](#hasVersion_items) | -           |
+| Each item of this array must be | Description                     |
+| ------------------------------- | ------------------------------- |
+| [Dataset](#hasVersion_items)    | Information about a set of data |
 
-### <a name="hasVersion_items"></a>Dataset > hasVersion > Dataset object or link
-
-**Title:** Dataset object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                        |
-| ------------------------------------- |
-| [Dataset](#hasVersion_items_anyOf_i0) |
-| [Link](#hasVersion_items_anyOf_i1)    |
-
-#### <a name="hasVersion_items_anyOf_i0"></a>Property `Dataset > hasVersion > Dataset object or link > anyOf > Dataset`
+### <a name="hasVersion_items"></a>Dataset > hasVersion > Dataset
 
 **Title:** Dataset
 
-inline description of Dataset
+Information about a set of data
 
-| **Type**                  | `object`                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                            |
-| **Same definition as**    | [Dataset](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0) |
-
-#### <a name="hasVersion_items_anyOf_i1"></a>Property `Dataset > hasVersion > Dataset object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Dataset
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                          |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
 
 ## <a name="inSeries"></a>Property `Dataset > inSeries`
 
@@ -549,43 +381,20 @@ List of Dataset Series this dataset belongs to
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                 | Description |
-| ----------------------------------------------- | ----------- |
-| [DatasetSeries object or link](#inSeries_items) | -           |
+| Each item of this array must be  | Description                   |
+| -------------------------------- | ----------------------------- |
+| [DatasetSeries](#inSeries_items) | An ordered series of datasets |
 
-### <a name="inSeries_items"></a>Dataset > inSeries > DatasetSeries object or link
-
-**Title:** DatasetSeries object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                            |
-| ----------------------------------------- |
-| [DatasetSeries](#inSeries_items_anyOf_i0) |
-| [Link](#inSeries_items_anyOf_i1)          |
-
-#### <a name="inSeries_items_anyOf_i0"></a>Property `Dataset > inSeries > DatasetSeries object or link > anyOf > DatasetSeries`
+### <a name="inSeries_items"></a>Dataset > inSeries > DatasetSeries
 
 **Title:** DatasetSeries
 
-inline description of DatasetSeries
+An ordered series of datasets
 
-| **Type**                  | `object`                                                                                                                  |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                          |
-| **Same definition as**    | [DatasetSeries](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_inSeries_items_anyOf_i0) |
-
-#### <a name="inSeries_items_anyOf_i1"></a>Property `Dataset > inSeries > DatasetSeries object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of DatasetSeries
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                       |
+| ------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                               |
+| **Same definition as**    | [DatasetSeries](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items) |
 
 ## <a name="keyword"></a>Property `Dataset > keyword`
 
@@ -632,7 +441,6 @@ A web page that provides access to the Dataset, its Distributions and/or additio
 | ------------------------------------------------------- |
 | [Null allowed when not required](#landingPage_anyOf_i0) |
 | [Document](#landingPage_anyOf_i1)                       |
-| [Link](#landingPage_anyOf_i2)                           |
 
 ### <a name="landingPage_anyOf_i0"></a>Property `Dataset > landingPage > anyOf > Null allowed when not required`
 
@@ -647,20 +455,10 @@ A web page that provides access to the Dataset, its Distributions and/or additio
 
 inline description of Document
 
-| **Type**                  | `object`                                                                                                          |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                  |
-| **Same definition as**    | [Document](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_landingPage_anyOf_i1) |
-
-### <a name="landingPage_anyOf_i2"></a>Property `Dataset > landingPage > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Document
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                |
+| **Same definition as**    | [Document](#sample_items_accessService_items_anyOf_i0_servesDataset_items_landingPage_anyOf_i1) |
 
 ## <a name="previousVersion"></a>Property `Dataset > previousVersion`
 
@@ -676,7 +474,6 @@ reference to the previous dataset version
 | ----------------------------------------------------------- |
 | [Null allowed when not required](#previousVersion_anyOf_i0) |
 | [Dataset](#previousVersion_anyOf_i1)                        |
-| [Link](#previousVersion_anyOf_i2)                           |
 
 ### <a name="previousVersion_anyOf_i0"></a>Property `Dataset > previousVersion > anyOf > Null allowed when not required`
 
@@ -691,20 +488,10 @@ reference to the previous dataset version
 
 inline description of Dataset
 
-| **Type**                  | `object`                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                            |
-| **Same definition as**    | [Dataset](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0) |
-
-### <a name="previousVersion_anyOf_i2"></a>Property `Dataset > previousVersion > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Dataset
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                          |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
 
 ## <a name="qualifiedRelation"></a>Property `Dataset > qualifiedRelation`
 
@@ -715,43 +502,20 @@ Qualified relationship with role of the dataset with another resource
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                         | Description |
-| ------------------------------------------------------- | ----------- |
-| [Relationship object or link](#qualifiedRelation_items) | -           |
+| Each item of this array must be          | Description                                                                                                    |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [Relationship](#qualifiedRelation_items) | Information about an item or entity that has some relationship to a dataset and the nature of the relationship |
 
-### <a name="qualifiedRelation_items"></a>Dataset > qualifiedRelation > Relationship object or link
-
-**Title:** Relationship object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                    |
-| ------------------------------------------------- |
-| [Relationship](#qualifiedRelation_items_anyOf_i0) |
-| [Link](#qualifiedRelation_items_anyOf_i1)         |
-
-#### <a name="qualifiedRelation_items_anyOf_i0"></a>Property `Dataset > qualifiedRelation > Relationship object or link > anyOf > Relationship`
+### <a name="qualifiedRelation_items"></a>Dataset > qualifiedRelation > Relationship
 
 **Title:** Relationship
 
-inline description of Relationship
+Information about an item or entity that has some relationship to a dataset and the nature of the relationship
 
-| **Type**                  | `object`                                                                                                                          |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                                  |
-| **Same definition as**    | [Relationship](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_qualifiedRelation_items_anyOf_i0) |
-
-#### <a name="qualifiedRelation_items_anyOf_i1"></a>Property `Dataset > qualifiedRelation > Relationship object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Relationship
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                                                                       |
+| **Same definition as**    | [Relationship](#sample_items_accessService_items_anyOf_i0_servesDataset_items_qualifiedRelation_items) |
 
 ## <a name="spatialResolutionInMeters"></a>Property `Dataset > spatialResolutionInMeters`
 
@@ -780,43 +544,20 @@ List of themes of the dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be | Description |
-| ------------------------------- | ----------- |
-| [Theme or link](#theme_items)   | -           |
+| Each item of this array must be | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [Concept](#theme_items)         | A labeled value from an optionally specified concept scheme |
 
-### <a name="theme_items"></a>Dataset > theme > Theme or link
-
-**Title:** Theme or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                   |
-| -------------------------------- |
-| [Concept](#theme_items_anyOf_i0) |
-| [Link](#theme_items_anyOf_i1)    |
-
-#### <a name="theme_items_anyOf_i0"></a>Property `Dataset > theme > Theme or link > anyOf > Concept`
+### <a name="theme_items"></a>Dataset > theme > Concept
 
 **Title:** Concept
 
-inline description of Concept
+A labeled value from an optionally specified concept scheme
 
-| **Type**                  | More than one type                                                 |
-| ------------------------- | ------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                   |
-| **Same definition as**    | [Concept](#sample_items_anyOf_i0_representationTechnique_anyOf_i1) |
-
-#### <a name="theme_items_anyOf_i1"></a>Property `Dataset > theme > Theme or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                        |
+| ------------------------- | --------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                          |
+| **Same definition as**    | [Concept](#sample_items_representationTechnique_anyOf_i1) |
 
 ## <a name="version"></a>Property `Dataset > version`
 
@@ -841,7 +582,6 @@ A distribution describing the Data Dictionary for this dataset
 | ------------------------------------------------------- |
 | [Null allowed when not required](#describedBy_anyOf_i0) |
 | [Distribution](#describedBy_anyOf_i1)                   |
-| [Link](#describedBy_anyOf_i2)                           |
 
 ### <a name="describedBy_anyOf_i0"></a>Property `Dataset > describedBy > anyOf > Null allowed when not required`
 
@@ -856,20 +596,10 @@ A distribution describing the Data Dictionary for this dataset
 
 inline description of Distribution
 
-| **Type**                  | `object`                               |
-| ------------------------- | -------------------------------------- |
-| **Additional properties** | Any type allowed                       |
-| **Same definition as**    | [Distribution](#sample_items_anyOf_i0) |
-
-### <a name="describedBy_anyOf_i2"></a>Property `Dataset > describedBy > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Distribution
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                      |
+| ------------------------- | ----------------------------- |
+| **Additional properties** | Any type allowed              |
+| **Same definition as**    | [Distribution](#sample_items) |
 
 ## <a name="liabilityStatement"></a>Property `Dataset > liabilityStatement`
 
@@ -885,7 +615,6 @@ A liability statement about the dataset that may clarify limitations of responsi
 | -------------------------------------------------------------- |
 | [Null allowed when not required](#liabilityStatement_anyOf_i0) |
 | [item 1](#liabilityStatement_anyOf_i1)                         |
-| [Link](#liabilityStatement_anyOf_i2)                           |
 
 ### <a name="liabilityStatement_anyOf_i0"></a>Property `Dataset > liabilityStatement > anyOf > Null allowed when not required`
 
@@ -901,16 +630,6 @@ Full text of the liability statement
 | **Type** | `string` |
 | -------- | -------- |
 
-### <a name="liabilityStatement_anyOf_i2"></a>Property `Dataset > liabilityStatement > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the liability statement
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
 ## <a name="metadataDistribution"></a>Property `Dataset > metadataDistribution`
 
 **Title:** metadata distribution
@@ -920,43 +639,20 @@ Distribution to "original" metadata document
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                            | Description |
-| ---------------------------------------------------------- | ----------- |
-| [Distribution object or link](#metadataDistribution_items) | -           |
+| Each item of this array must be             | Description                         |
+| ------------------------------------------- | ----------------------------------- |
+| [Distribution](#metadataDistribution_items) | A file that distributes the dataset |
 
-### <a name="metadataDistribution_items"></a>Dataset > metadataDistribution > Distribution object or link
-
-**Title:** Distribution object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                       |
-| ---------------------------------------------------- |
-| [Distribution](#metadataDistribution_items_anyOf_i0) |
-| [Link](#metadataDistribution_items_anyOf_i1)         |
-
-#### <a name="metadataDistribution_items_anyOf_i0"></a>Property `Dataset > metadataDistribution > Distribution object or link > anyOf > Distribution`
+### <a name="metadataDistribution_items"></a>Dataset > metadataDistribution > Distribution
 
 **Title:** Distribution
 
-inline description of Distribution
+A file that distributes the dataset
 
-| **Type**                  | `object`                               |
-| ------------------------- | -------------------------------------- |
-| **Additional properties** | Any type allowed                       |
-| **Same definition as**    | [Distribution](#sample_items_anyOf_i0) |
-
-#### <a name="metadataDistribution_items_anyOf_i1"></a>Property `Dataset > metadataDistribution > Distribution object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Distribution
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                      |
+| ------------------------- | ----------------------------- |
+| **Additional properties** | Any type allowed              |
+| **Same definition as**    | [Distribution](#sample_items) |
 
 ## <a name="purpose"></a>Property `Dataset > purpose`
 
@@ -988,7 +684,6 @@ Information that indicates whether the Dataset is open data, has access restrict
 | -------------------------------------------------------- |
 | [Null allowed when not required](#accessRights_anyOf_i0) |
 | [item 1](#accessRights_anyOf_i1)                         |
-| [Link](#accessRights_anyOf_i2)                           |
 
 ### <a name="accessRights_anyOf_i0"></a>Property `Dataset > accessRights > anyOf > Null allowed when not required`
 
@@ -1003,16 +698,6 @@ Text description of the access rights
 
 | **Type** | `string` |
 | -------- | -------- |
-
-### <a name="accessRights_anyOf_i2"></a>Property `Dataset > accessRights > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the access rights
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="accrualPeriodicity"></a>Property `Dataset > accrualPeriodicity`
 
@@ -1105,43 +790,20 @@ List of standards to which the described Dataset conforms
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be              | Description |
-| -------------------------------------------- | ----------- |
-| [Standard object or link](#conformsTo_items) | -           |
+| Each item of this array must be | Description                                                           |
+| ------------------------------- | --------------------------------------------------------------------- |
+| [Standard](#conformsTo_items)   | Information about a particular standard that another item conforms to |
 
-### <a name="conformsTo_items"></a>Dataset > conformsTo > Standard object or link
-
-**Title:** Standard object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                         |
-| -------------------------------------- |
-| [Standard](#conformsTo_items_anyOf_i0) |
-| [Link](#conformsTo_items_anyOf_i1)     |
-
-#### <a name="conformsTo_items_anyOf_i0"></a>Property `Dataset > conformsTo > Standard object or link > anyOf > Standard`
+### <a name="conformsTo_items"></a>Dataset > conformsTo > Standard
 
 **Title:** Standard
 
-inline description of Standard
+Information about a particular standard that another item conforms to
 
-| **Type**                  | `object`                                                                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                                            |
-| **Same definition as**    | [Standard](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_landingPage_anyOf_i1_conformsTo_items_anyOf_i0) |
-
-#### <a name="conformsTo_items_anyOf_i1"></a>Property `Dataset > conformsTo > Standard object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Standard
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                                         |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                                 |
+| **Same definition as**    | [Standard](#sample_items_accessService_items_anyOf_i0_servesDataset_items_landingPage_anyOf_i1_conformsTo_items) |
 
 ## <a name="contributor"></a>Property `Dataset > contributor`
 
@@ -1152,43 +814,20 @@ List of agents contributing to the Dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be            | Description |
-| ------------------------------------------ | ----------- |
-| [Agent object or link](#contributor_items) | -           |
+| Each item of this array must be | Description                                      |
+| ------------------------------- | ------------------------------------------------ |
+| [Agent](#contributor_items)     | An entity that could be involved with a resource |
 
-### <a name="contributor_items"></a>Dataset > contributor > Agent object or link
-
-**Title:** Agent object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                       |
-| ------------------------------------ |
-| [Agent](#contributor_items_anyOf_i0) |
-| [Link](#contributor_items_anyOf_i1)  |
-
-#### <a name="contributor_items_anyOf_i0"></a>Property `Dataset > contributor > Agent object or link > anyOf > Agent`
+### <a name="contributor_items"></a>Dataset > contributor > Agent
 
 **Title:** Agent
 
-inline description of Agent
+An entity that could be involved with a resource
 
-| **Type**                  | `object`                                                                                                                             |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                                                                                     |
-| **Same definition as**    | [Agent](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_inSeries_items_anyOf_i0_publisher_anyOf_i1) |
-
-#### <a name="contributor_items_anyOf_i1"></a>Property `Dataset > contributor > Agent object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Agent
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                                  |
+| ------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                          |
+| **Same definition as**    | [Agent](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items_publisher_anyOf_i1) |
 
 ## <a name="created"></a>Property `Dataset > created`
 
@@ -1275,7 +914,6 @@ An entity responsible for producing the dataset
 | --------------------------------------------------- |
 | [Null allowed when not required](#creator_anyOf_i0) |
 | [Agent](#creator_anyOf_i1)                          |
-| [Link](#creator_anyOf_i2)                           |
 
 ### <a name="creator_anyOf_i0"></a>Property `Dataset > creator > anyOf > Null allowed when not required`
 
@@ -1290,20 +928,10 @@ An entity responsible for producing the dataset
 
 inline description of Agent
 
-| **Type**                  | `object`                                                                                                                             |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                                                                                     |
-| **Same definition as**    | [Agent](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_inSeries_items_anyOf_i0_publisher_anyOf_i1) |
-
-### <a name="creator_anyOf_i2"></a>Property `Dataset > creator > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Agent
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                                  |
+| ------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                          |
+| **Same definition as**    | [Agent](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items_publisher_anyOf_i1) |
 
 ## <a name="description"></a>Property `Dataset > description`
 
@@ -1331,43 +959,20 @@ List of related datasets that are part of the described dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be          | Description |
-| ---------------------------------------- | ----------- |
-| [Dataset object or link](#hasPart_items) | -           |
+| Each item of this array must be | Description                     |
+| ------------------------------- | ------------------------------- |
+| [Dataset](#hasPart_items)       | Information about a set of data |
 
-### <a name="hasPart_items"></a>Dataset > hasPart > Dataset object or link
-
-**Title:** Dataset object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                     |
-| ---------------------------------- |
-| [Dataset](#hasPart_items_anyOf_i0) |
-| [Link](#hasPart_items_anyOf_i1)    |
-
-#### <a name="hasPart_items_anyOf_i0"></a>Property `Dataset > hasPart > Dataset object or link > anyOf > Dataset`
+### <a name="hasPart_items"></a>Dataset > hasPart > Dataset
 
 **Title:** Dataset
 
-inline description of Dataset
+Information about a set of data
 
-| **Type**                  | `object`                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                            |
-| **Same definition as**    | [Dataset](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0) |
-
-#### <a name="hasPart_items_anyOf_i1"></a>Property `Dataset > hasPart > Dataset object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Dataset
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                          |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
 
 ## <a name="identifier"></a>Property `Dataset > identifier`
 
@@ -1383,7 +988,6 @@ The unique identifier for the Dataset, e.g. the URI or other unique identifier i
 | ------------------------------------------------------ |
 | [Null allowed when not required](#identifier_anyOf_i0) |
 | [Identifier](#identifier_anyOf_i1)                     |
-| [Link](#identifier_anyOf_i2)                           |
 
 ### <a name="identifier_anyOf_i0"></a>Property `Dataset > identifier > anyOf > Null allowed when not required`
 
@@ -1398,20 +1002,10 @@ The unique identifier for the Dataset, e.g. the URI or other unique identifier i
 
 inline description of Identifier
 
-| **Type**                  | More than one type                            |
-| ------------------------- | --------------------------------------------- |
-| **Additional properties** | Any type allowed                              |
-| **Same definition as**    | [Identifier](#otherIdentifier_items_anyOf_i0) |
-
-### <a name="identifier_anyOf_i2"></a>Property `Dataset > identifier > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                   |
+| ------------------------- | ------------------------------------ |
+| **Additional properties** | Any type allowed                     |
+| **Same definition as**    | [Identifier](#otherIdentifier_items) |
 
 ## <a name="isReferencedBy"></a>Property `Dataset > isReferencedBy`
 
@@ -1640,42 +1234,19 @@ A year and month in YYYY-MM format
 
 List of statements about the lineage of a Dataset, including any changes in its ownership or custody since its creation that may be significant for its authenticity, integrity, or interpretation
 
-| **Type** | `null or array` |
-| -------- | --------------- |
+| **Type** | `null or array of string` |
+| -------- | ------------------------- |
 
-| Each item of this array must be                        | Description |
-| ------------------------------------------------------ | ----------- |
-| [Provenance statement text or link](#provenance_items) | -           |
+| Each item of this array must be       | Description                           |
+| ------------------------------------- | ------------------------------------- |
+| [provenance items](#provenance_items) | Full text of the provenance statement |
 
-### <a name="provenance_items"></a>Dataset > provenance > Provenance statement text or link
-
-**Title:** Provenance statement text or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                       |
-| ------------------------------------ |
-| [item 0](#provenance_items_anyOf_i0) |
-| [Link](#provenance_items_anyOf_i1)   |
-
-#### <a name="provenance_items_anyOf_i0"></a>Property `Dataset > provenance > Provenance statement text or link > anyOf > item 0`
+### <a name="provenance_items"></a>Dataset > provenance > provenance items
 
 Full text of the provenance statement
 
 | **Type** | `string` |
 | -------- | -------- |
-
-#### <a name="provenance_items_anyOf_i1"></a>Property `Dataset > provenance > Provenance statement text or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the provenance statement
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="publisher"></a>Property `Dataset > publisher`
 
@@ -1683,36 +1254,11 @@ reference iri of the provenance statement
 
 An organization responsible for making the Dataset available
 
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Required**              | Yes                |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Organization](#publisher_anyOf_i0) |
-| [Link](#publisher_anyOf_i1)         |
-
-### <a name="publisher_anyOf_i0"></a>Property `Dataset > publisher > anyOf > Organization`
-
-**Title:** Organization
-
-inline description of Organization
-
-| **Type**                  | `object`                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                          |
-| **Same definition as**    | [Organization](#otherIdentifier_items_anyOf_i0_anyOf_i1_creator_anyOf_i1) |
-
-### <a name="publisher_anyOf_i1"></a>Property `Dataset > publisher > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Organization
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                          |
+| ------------------------- | --------------------------------- |
+| **Required**              | Yes                               |
+| **Additional properties** | Any type allowed                  |
+| **Defined in**            | [Organization](./Organization.md) |
 
 ## <a name="relation"></a>Property `Dataset > relation`
 
@@ -1746,43 +1292,20 @@ List of Datasets replaced by this Dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be           | Description |
-| ----------------------------------------- | ----------- |
-| [Dataset object or link](#replaces_items) | -           |
+| Each item of this array must be | Description                     |
+| ------------------------------- | ------------------------------- |
+| [Dataset](#replaces_items)      | Information about a set of data |
 
-### <a name="replaces_items"></a>Dataset > replaces > Dataset object or link
-
-**Title:** Dataset object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Dataset](#replaces_items_anyOf_i0) |
-| [Link](#replaces_items_anyOf_i1)    |
-
-#### <a name="replaces_items_anyOf_i0"></a>Property `Dataset > replaces > Dataset object or link > anyOf > Dataset`
+### <a name="replaces_items"></a>Dataset > replaces > Dataset
 
 **Title:** Dataset
 
-inline description of Dataset
+Information about a set of data
 
-| **Type**                  | `object`                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                            |
-| **Same definition as**    | [Dataset](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0) |
-
-#### <a name="replaces_items_anyOf_i1"></a>Property `Dataset > replaces > Dataset object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Dataset
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                          |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
 
 ## <a name="rights"></a>Property `Dataset > rights`
 
@@ -1790,42 +1313,19 @@ reference iri of Dataset
 
 A list of statements concerning all rights for the Dataset that may not be addressed by license or accessRights, such as copyright statements, statements about the intellectual property rights (IPR), or information regarding access or restrictions based on privacy, security, or other policies
 
-| **Type** | `null or array` |
-| -------- | --------------- |
+| **Type** | `null or array of string` |
+| -------- | ------------------------- |
 
-| Each item of this array must be              | Description |
-| -------------------------------------------- | ----------- |
-| [Statement of rights or link](#rights_items) | -           |
+| Each item of this array must be | Description                        |
+| ------------------------------- | ---------------------------------- |
+| [rights items](#rights_items)   | Full text of a statement of rights |
 
-### <a name="rights_items"></a>Dataset > rights > Statement of rights or link
-
-**Title:** Statement of rights or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                   |
-| -------------------------------- |
-| [item 0](#rights_items_anyOf_i0) |
-| [Link](#rights_items_anyOf_i1)   |
-
-#### <a name="rights_items_anyOf_i0"></a>Property `Dataset > rights > Statement of rights or link > anyOf > item 0`
+### <a name="rights_items"></a>Dataset > rights > rights items
 
 Full text of a statement of rights
 
 | **Type** | `string` |
 | -------- | -------- |
-
-#### <a name="rights_items_anyOf_i1"></a>Property `Dataset > rights > Statement of rights or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of a statement of rights
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="rightsHolder"></a>Property `Dataset > rightsHolder`
 
@@ -1836,43 +1336,20 @@ List of agents (organizations) holding rights on the Dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be             | Description |
-| ------------------------------------------- | ----------- |
-| [Organization or link](#rightsHolder_items) | -           |
+| Each item of this array must be     | Description                                                                         |
+| ----------------------------------- | ----------------------------------------------------------------------------------- |
+| [Organization](#rightsHolder_items) | Information about an organization, including other organizations that it is part of |
 
-### <a name="rightsHolder_items"></a>Dataset > rightsHolder > Organization or link
-
-**Title:** Organization or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                               |
-| -------------------------------------------- |
-| [Organization](#rightsHolder_items_anyOf_i0) |
-| [Link](#rightsHolder_items_anyOf_i1)         |
-
-#### <a name="rightsHolder_items_anyOf_i0"></a>Property `Dataset > rightsHolder > Organization or link > anyOf > Organization`
+### <a name="rightsHolder_items"></a>Dataset > rightsHolder > Organization
 
 **Title:** Organization
 
-inline description of Organization
+Information about an organization, including other organizations that it is part of
 
-| **Type**                  | `object`                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                          |
-| **Same definition as**    | [Organization](#otherIdentifier_items_anyOf_i0_anyOf_i1_creator_anyOf_i1) |
-
-#### <a name="rightsHolder_items_anyOf_i1"></a>Property `Dataset > rightsHolder > Organization or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Organization
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                         |
+| ------------------------- | ---------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                 |
+| **Same definition as**    | [Organization](#otherIdentifier_items_anyOf_i1_creator_anyOf_i1) |
 
 ## <a name="source"></a>Property `Dataset > source`
 
@@ -1883,43 +1360,20 @@ List of related Datasets from which the described Dataset is derived
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be         | Description |
-| --------------------------------------- | ----------- |
-| [Dataset object or link](#source_items) | -           |
+| Each item of this array must be | Description                     |
+| ------------------------------- | ------------------------------- |
+| [Dataset](#source_items)        | Information about a set of data |
 
-### <a name="source_items"></a>Dataset > source > Dataset object or link
-
-**Title:** Dataset object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                    |
-| --------------------------------- |
-| [Dataset](#source_items_anyOf_i0) |
-| [Link](#source_items_anyOf_i1)    |
-
-#### <a name="source_items_anyOf_i0"></a>Property `Dataset > source > Dataset object or link > anyOf > Dataset`
+### <a name="source_items"></a>Dataset > source > Dataset
 
 **Title:** Dataset
 
-inline description of Dataset
+Information about a set of data
 
-| **Type**                  | `object`                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                            |
-| **Same definition as**    | [Dataset](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0) |
-
-#### <a name="source_items_anyOf_i1"></a>Property `Dataset > source > Dataset object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Dataset
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                          |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
 
 ## <a name="spatial"></a>Property `Dataset > spatial`
 
@@ -1935,8 +1389,7 @@ A geographic region or regions that are covered by the Dataset
 | --------------------------------------------------- |
 | [Null allowed when not required](#spatial_anyOf_i0) |
 | [Location](#spatial_anyOf_i1)                       |
-| [Link](#spatial_anyOf_i2)                           |
-| [List of geographic regions](#spatial_anyOf_i3)     |
+| [List of geographic regions](#spatial_anyOf_i2)     |
 
 ### <a name="spatial_anyOf_i0"></a>Property `Dataset > spatial > anyOf > Null allowed when not required`
 
@@ -1951,65 +1404,32 @@ A geographic region or regions that are covered by the Dataset
 
 inline description of Location
 
-| **Type**                  | `object`                                                                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                                            |
-| **Same definition as**    | [Location](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_inSeries_items_anyOf_i0_spatial_items_anyOf_i0) |
+| **Type**                  | `object`                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                        |
+| **Same definition as**    | [Location](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items_spatial_items) |
 
-### <a name="spatial_anyOf_i2"></a>Property `Dataset > spatial > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Location
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
-### <a name="spatial_anyOf_i3"></a>Property `Dataset > spatial > anyOf > List of geographic regions`
+### <a name="spatial_anyOf_i2"></a>Property `Dataset > spatial > anyOf > List of geographic regions`
 
 **Title:** List of geographic regions
 
 | **Type** | `array` |
 | -------- | ------- |
 
-| Each item of this array must be             | Description |
-| ------------------------------------------- | ----------- |
-| [Location or link](#spatial_anyOf_i3_items) | -           |
+| Each item of this array must be     | Description                                      |
+| ----------------------------------- | ------------------------------------------------ |
+| [Location](#spatial_anyOf_i2_items) | Information about a specific geographic location |
 
-#### <a name="spatial_anyOf_i3_items"></a>Dataset > spatial > anyOf > List of geographic regions > Location or link
-
-**Title:** Location or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                               |
-| -------------------------------------------- |
-| [Location](#spatial_anyOf_i3_items_anyOf_i0) |
-| [Link](#spatial_anyOf_i3_items_anyOf_i1)     |
-
-##### <a name="spatial_anyOf_i3_items_anyOf_i0"></a>Property `Dataset > spatial > anyOf > List of geographic regions > Location or link > anyOf > Location`
+#### <a name="spatial_anyOf_i2_items"></a>Dataset > spatial > anyOf > List of geographic regions > Location
 
 **Title:** Location
 
-inline description of Location
+Information about a specific geographic location
 
-| **Type**                  | `object`                                                                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                                            |
-| **Same definition as**    | [Location](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_inSeries_items_anyOf_i0_spatial_items_anyOf_i0) |
-
-##### <a name="spatial_anyOf_i3_items_anyOf_i1"></a>Property `Dataset > spatial > anyOf > List of geographic regions > Location or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Location
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                        |
+| **Same definition as**    | [Location](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items_spatial_items) |
 
 ## <a name="subject"></a>Property `Dataset > subject`
 
@@ -2020,43 +1440,20 @@ List of primary subjects of the dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be   | Description |
-| --------------------------------- | ----------- |
-| [Subject or link](#subject_items) | -           |
+| Each item of this array must be | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [Concept](#subject_items)       | A labeled value from an optionally specified concept scheme |
 
-### <a name="subject_items"></a>Dataset > subject > Subject or link
-
-**Title:** Subject or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                     |
-| ---------------------------------- |
-| [Concept](#subject_items_anyOf_i0) |
-| [Link](#subject_items_anyOf_i1)    |
-
-#### <a name="subject_items_anyOf_i0"></a>Property `Dataset > subject > Subject or link > anyOf > Concept`
+### <a name="subject_items"></a>Dataset > subject > Concept
 
 **Title:** Concept
 
-inline description of Concept
+A labeled value from an optionally specified concept scheme
 
-| **Type**                  | More than one type                                                 |
-| ------------------------- | ------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                   |
-| **Same definition as**    | [Concept](#sample_items_anyOf_i0_representationTechnique_anyOf_i1) |
-
-#### <a name="subject_items_anyOf_i1"></a>Property `Dataset > subject > Subject or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                        |
+| ------------------------- | --------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                          |
+| **Same definition as**    | [Concept](#sample_items_representationTechnique_anyOf_i1) |
 
 ## <a name="temporal"></a>Property `Dataset > temporal`
 
@@ -2067,43 +1464,20 @@ List of temporal periods that the dataset covers
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [PeriodOfTime object or link](#temporal_items) | -           |
+| Each item of this array must be | Description                                                            |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| [PeriodOfTime](#temporal_items) | Information about a specific time period with a start- and/or end-time |
 
-### <a name="temporal_items"></a>Dataset > temporal > PeriodOfTime object or link
-
-**Title:** PeriodOfTime object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                           |
-| ---------------------------------------- |
-| [PeriodOfTime](#temporal_items_anyOf_i0) |
-| [Link](#temporal_items_anyOf_i1)         |
-
-#### <a name="temporal_items_anyOf_i0"></a>Property `Dataset > temporal > PeriodOfTime object or link > anyOf > PeriodOfTime`
+### <a name="temporal_items"></a>Dataset > temporal > PeriodOfTime
 
 **Title:** PeriodOfTime
 
-inline description of PeriodOfTime
+Information about a specific time period with a start- and/or end-time
 
-| **Type**                  | `object`                                                                                                                                         |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                                                                                                 |
-| **Same definition as**    | [PeriodOfTime](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_inSeries_items_anyOf_i0_temporal_items_anyOf_i0) |
-
-#### <a name="temporal_items_anyOf_i1"></a>Property `Dataset > temporal > PeriodOfTime object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of PeriodOfTime
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                                                                             |
+| **Same definition as**    | [PeriodOfTime](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items_temporal_items) |
 
 ## <a name="title"></a>Property `Dataset > title`
 
@@ -2131,43 +1505,20 @@ List of categories for the Dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be     | Description |
-| ----------------------------------- | ----------- |
-| [Category or link](#category_items) | -           |
+| Each item of this array must be | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [Concept](#category_items)      | A labeled value from an optionally specified concept scheme |
 
-### <a name="category_items"></a>Dataset > category > Category or link
-
-**Title:** Category or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Concept](#category_items_anyOf_i0) |
-| [Link](#category_items_anyOf_i1)    |
-
-#### <a name="category_items_anyOf_i0"></a>Property `Dataset > category > Category or link > anyOf > Concept`
+### <a name="category_items"></a>Dataset > category > Concept
 
 **Title:** Concept
 
-inline description of Concept
+A labeled value from an optionally specified concept scheme
 
-| **Type**                  | More than one type                                                 |
-| ------------------------- | ------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                   |
-| **Same definition as**    | [Concept](#sample_items_anyOf_i0_representationTechnique_anyOf_i1) |
-
-#### <a name="category_items_anyOf_i1"></a>Property `Dataset > category > Category or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                        |
+| ------------------------- | --------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                          |
+| **Same definition as**    | [Concept](#sample_items_representationTechnique_anyOf_i1) |
 
 ## <a name="hasQualityMeasurement"></a>Property `Dataset > hasQualityMeasurement`
 
@@ -2178,42 +1529,20 @@ List of quality measurements for the dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                            | Description |
-| ---------------------------------------------------------- | ----------- |
-| [QualityMeasurement or link](#hasQualityMeasurement_items) | -           |
+| Each item of this array must be                    | Description                        |
+| -------------------------------------------------- | ---------------------------------- |
+| [QualityMeasurement](#hasQualityMeasurement_items) | A single measurement of one metric |
 
-### <a name="hasQualityMeasurement_items"></a>Dataset > hasQualityMeasurement > QualityMeasurement or link
-
-**Title:** QualityMeasurement or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                              |
-| ----------------------------------------------------------- |
-| [QualityMeasurement](#hasQualityMeasurement_items_anyOf_i0) |
-| [Link](#hasQualityMeasurement_items_anyOf_i1)               |
-
-#### <a name="hasQualityMeasurement_items_anyOf_i0"></a>Property `Dataset > hasQualityMeasurement > QualityMeasurement or link > anyOf > QualityMeasurement`
+### <a name="hasQualityMeasurement_items"></a>Dataset > hasQualityMeasurement > QualityMeasurement
 
 **Title:** QualityMeasurement
 
-inline description of QualityMeasurement
+A single measurement of one metric
 
-| **Type**                  | `object`                                                                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                                            |
-| **Same definition as**    | [QualityMeasurement](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_hasQualityMeasurement_items_anyOf_i0) |
-
-#### <a name="hasQualityMeasurement_items_anyOf_i1"></a>Property `Dataset > hasQualityMeasurement > QualityMeasurement or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of QualityMeasurement
-
-| **Type** | `string` |
-| -------- | -------- |
+| **Type**                  | `object`                                                                                                         |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                                 |
+| **Same definition as**    | [QualityMeasurement](#sample_items_accessService_items_anyOf_i0_servesDataset_items_hasQualityMeasurement_items) |
 
 ## <a name="page"></a>Property `Dataset > page`
 
@@ -2224,43 +1553,20 @@ List of pages or documents about this dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be        | Description |
-| -------------------------------------- | ----------- |
-| [Document object or link](#page_items) | -           |
+| Each item of this array must be | Description                       |
+| ------------------------------- | --------------------------------- |
+| [Document](#page_items)         | Information about a text document |
 
-### <a name="page_items"></a>Dataset > page > Document object or link
-
-**Title:** Document object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                   |
-| -------------------------------- |
-| [Document](#page_items_anyOf_i0) |
-| [Link](#page_items_anyOf_i1)     |
-
-#### <a name="page_items_anyOf_i0"></a>Property `Dataset > page > Document object or link > anyOf > Document`
+### <a name="page_items"></a>Dataset > page > Document
 
 **Title:** Document
 
-inline description of Document
+Information about a text document
 
-| **Type**                  | `object`                                                                                                          |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                  |
-| **Same definition as**    | [Document](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_landingPage_anyOf_i1) |
-
-#### <a name="page_items_anyOf_i1"></a>Property `Dataset > page > Document object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Document
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                |
+| **Same definition as**    | [Document](#sample_items_accessService_items_anyOf_i0_servesDataset_items_landingPage_anyOf_i1) |
 
 ## <a name="qualifiedAttribution"></a>Property `Dataset > qualifiedAttribution`
 
@@ -2271,43 +1577,20 @@ List of agents having some form of responsibility for the dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                           | Description |
-| --------------------------------------------------------- | ----------- |
-| [Attribution object or link](#qualifiedAttribution_items) | -           |
+| Each item of this array must be            | Description                                  |
+| ------------------------------------------ | -------------------------------------------- |
+| [Attribution](#qualifiedAttribution_items) | An attribution that an agent plays some role |
 
-### <a name="qualifiedAttribution_items"></a>Dataset > qualifiedAttribution > Attribution object or link
-
-**Title:** Attribution object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                      |
-| --------------------------------------------------- |
-| [Attribution](#qualifiedAttribution_items_anyOf_i0) |
-| [Link](#qualifiedAttribution_items_anyOf_i1)        |
-
-#### <a name="qualifiedAttribution_items_anyOf_i0"></a>Property `Dataset > qualifiedAttribution > Attribution object or link > anyOf > Attribution`
+### <a name="qualifiedAttribution_items"></a>Dataset > qualifiedAttribution > Attribution
 
 **Title:** Attribution
 
-inline description of Attribution
+An attribution that an agent plays some role
 
-| **Type**                  | `object`                                                                                                                            |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                                    |
-| **Same definition as**    | [Attribution](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_qualifiedAttribution_items_anyOf_i0) |
-
-#### <a name="qualifiedAttribution_items_anyOf_i1"></a>Property `Dataset > qualifiedAttribution > Attribution object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Attribution
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                                 |
+| ------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                         |
+| **Same definition as**    | [Attribution](#sample_items_accessService_items_anyOf_i0_servesDataset_items_qualifiedAttribution_items) |
 
 ## <a name="wasAttributedTo"></a>Property `Dataset > wasAttributedTo`
 
@@ -2318,43 +1601,20 @@ List of agents attributed to this dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [Agent object or link](#wasAttributedTo_items) | -           |
+| Each item of this array must be | Description                                      |
+| ------------------------------- | ------------------------------------------------ |
+| [Agent](#wasAttributedTo_items) | An entity that could be involved with a resource |
 
-### <a name="wasAttributedTo_items"></a>Dataset > wasAttributedTo > Agent object or link
-
-**Title:** Agent object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                           |
-| ---------------------------------------- |
-| [Agent](#wasAttributedTo_items_anyOf_i0) |
-| [Link](#wasAttributedTo_items_anyOf_i1)  |
-
-#### <a name="wasAttributedTo_items_anyOf_i0"></a>Property `Dataset > wasAttributedTo > Agent object or link > anyOf > Agent`
+### <a name="wasAttributedTo_items"></a>Dataset > wasAttributedTo > Agent
 
 **Title:** Agent
 
-inline description of Agent
+An entity that could be involved with a resource
 
-| **Type**                  | `object`                                                                                                                             |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                                                                                     |
-| **Same definition as**    | [Agent](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_inSeries_items_anyOf_i0_publisher_anyOf_i1) |
-
-#### <a name="wasAttributedTo_items_anyOf_i1"></a>Property `Dataset > wasAttributedTo > Agent object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Agent
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                                  |
+| ------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                          |
+| **Same definition as**    | [Agent](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items_publisher_anyOf_i1) |
 
 ## <a name="wasGeneratedBy"></a>Property `Dataset > wasGeneratedBy`
 
@@ -2365,43 +1625,20 @@ List of activities that generated, or provide the business context for the creat
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                  | Description |
-| ------------------------------------------------ | ----------- |
-| [Activity object or link](#wasGeneratedBy_items) | -           |
+| Each item of this array must be   | Description                                      |
+| --------------------------------- | ------------------------------------------------ |
+| [Activity](#wasGeneratedBy_items) | An activity which a resource could be related to |
 
-### <a name="wasGeneratedBy_items"></a>Dataset > wasGeneratedBy > Activity object or link
-
-**Title:** Activity object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                             |
-| ------------------------------------------ |
-| [Activity](#wasGeneratedBy_items_anyOf_i0) |
-| [Link](#wasGeneratedBy_items_anyOf_i1)     |
-
-#### <a name="wasGeneratedBy_items_anyOf_i0"></a>Property `Dataset > wasGeneratedBy > Activity object or link > anyOf > Activity`
+### <a name="wasGeneratedBy_items"></a>Dataset > wasGeneratedBy > Activity
 
 **Title:** Activity
 
-inline description of Activity
+An activity which a resource could be related to
 
-| **Type**                  | `object`                                                                                                                   |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                           |
-| **Same definition as**    | [Activity](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_wasGeneratedBy_items_anyOf_i0) |
-
-#### <a name="wasGeneratedBy_items_anyOf_i1"></a>Property `Dataset > wasGeneratedBy > Activity object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Activity
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                |
+| **Same definition as**    | [Activity](#sample_items_accessService_items_anyOf_i0_servesDataset_items_wasGeneratedBy_items) |
 
 ## <a name="wasUsedBy"></a>Property `Dataset > wasUsedBy`
 
@@ -2412,43 +1649,20 @@ List of activities that used the Dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be             | Description |
-| ------------------------------------------- | ----------- |
-| [Activity object or link](#wasUsedBy_items) | -           |
+| Each item of this array must be | Description                                      |
+| ------------------------------- | ------------------------------------------------ |
+| [Activity](#wasUsedBy_items)    | An activity which a resource could be related to |
 
-### <a name="wasUsedBy_items"></a>Dataset > wasUsedBy > Activity object or link
-
-**Title:** Activity object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                        |
-| ------------------------------------- |
-| [Activity](#wasUsedBy_items_anyOf_i0) |
-| [Link](#wasUsedBy_items_anyOf_i1)     |
-
-#### <a name="wasUsedBy_items_anyOf_i0"></a>Property `Dataset > wasUsedBy > Activity object or link > anyOf > Activity`
+### <a name="wasUsedBy_items"></a>Dataset > wasUsedBy > Activity
 
 **Title:** Activity
 
-inline description of Activity
+An activity which a resource could be related to
 
-| **Type**                  | `object`                                                                                                                   |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                           |
-| **Same definition as**    | [Activity](#sample_items_anyOf_i0_accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_wasGeneratedBy_items_anyOf_i0) |
-
-#### <a name="wasUsedBy_items_anyOf_i1"></a>Property `Dataset > wasUsedBy > Activity object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Activity
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                |
+| **Same definition as**    | [Activity](#sample_items_accessService_items_anyOf_i0_servesDataset_items_wasGeneratedBy_items) |
 
 ## <a name="image"></a>Property `Dataset > image`
 

--- a/jsonschema/docs/Dataset.md
+++ b/jsonschema/docs/Dataset.md
@@ -48,11 +48,11 @@ Information about a set of data
 | - [issued](#issued )                                       | More than one type      | release date                |
 | - [language](#language )                                   | More than one type      | language                    |
 | - [modified](#modified )                                   | More than one type      | last modified               |
-| - [provenance](#provenance )                               | null or array           | provenance                  |
-| + [publisher](#publisher )                                 | More than one type      | publisher                   |
+| - [provenance](#provenance )                               | null or array of string | provenance                  |
+| + [publisher](#publisher )                                 | object                  | publisher                   |
 | - [relation](#relation )                                   | null or array of string | related resource            |
 | - [replaces](#replaces )                                   | null or array           | replaces                    |
-| - [rights](#rights )                                       | null or array           | rights                      |
+| - [rights](#rights )                                       | null or array of string | rights                      |
 | - [rightsHolder](#rightsHolder )                           | null or array           | rights holder               |
 | - [source](#source )                                       | null or array           | data source                 |
 | - [spatial](#spatial )                                     | More than one type      | spatial/geographic coverage |

--- a/jsonschema/docs/Dataset.md
+++ b/jsonschema/docs/Dataset.md
@@ -195,10 +195,10 @@ supported schema for this dataset
 
 inline description of the supported schema
 
-| **Type**                  | `object`                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                          |
-| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
+| **Type**                  | `object`                                                         |
+| ------------------------- | ---------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                 |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_servesDataset_items) |
 
 ## <a name="versionNotes"></a>Property `Dataset > versionNotes`
 
@@ -231,10 +231,10 @@ A single contact point or list of contact information that can be used for sendi
 
 inline description of Kind
 
-| **Type**                  | `object`                                                              |
-| ------------------------- | --------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                      |
-| **Same definition as**    | [Kind](#sample_items_accessService_items_anyOf_i0_contactPoint_items) |
+| **Type**                  | `object`                                                     |
+| ------------------------- | ------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                             |
+| **Same definition as**    | [Kind](#sample_items_accessService_items_contactPoint_items) |
 
 ### <a name="contactPoint_anyOf_i1"></a>Property `Dataset > contactPoint > anyOf > List of contacts`
 
@@ -253,10 +253,10 @@ inline description of Kind
 
 Contact information for an individual or entity
 
-| **Type**                  | `object`                                                              |
-| ------------------------- | --------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                      |
-| **Same definition as**    | [Kind](#sample_items_accessService_items_anyOf_i0_contactPoint_items) |
+| **Type**                  | `object`                                                     |
+| ------------------------- | ------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                             |
+| **Same definition as**    | [Kind](#sample_items_accessService_items_contactPoint_items) |
 
 ## <a name="distribution"></a>Property `Dataset > distribution`
 
@@ -310,10 +310,10 @@ the first item of the sequence the dataset belongs to
 
 inline description of Dataset
 
-| **Type**                  | `object`                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                          |
-| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
+| **Type**                  | `object`                                                         |
+| ------------------------- | ---------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                 |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_servesDataset_items) |
 
 ## <a name="hasCurrentVersion"></a>Property `Dataset > hasCurrentVersion`
 
@@ -343,10 +343,10 @@ reference to the current (latest) version of a dataset
 
 inline description of Dataset
 
-| **Type**                  | `object`                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                          |
-| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
+| **Type**                  | `object`                                                         |
+| ------------------------- | ---------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                 |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_servesDataset_items) |
 
 ## <a name="hasVersion"></a>Property `Dataset > hasVersion`
 
@@ -367,10 +367,10 @@ List of related Datasets that are a version, edition, or adaptation of the descr
 
 Information about a set of data
 
-| **Type**                  | `object`                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                          |
-| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
+| **Type**                  | `object`                                                         |
+| ------------------------- | ---------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                 |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_servesDataset_items) |
 
 ## <a name="inSeries"></a>Property `Dataset > inSeries`
 
@@ -391,10 +391,10 @@ List of Dataset Series this dataset belongs to
 
 An ordered series of datasets
 
-| **Type**                  | `object`                                                                                       |
-| ------------------------- | ---------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                               |
-| **Same definition as**    | [DatasetSeries](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items) |
+| **Type**                  | `object`                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                      |
+| **Same definition as**    | [DatasetSeries](#sample_items_accessService_items_servesDataset_items_inSeries_items) |
 
 ## <a name="keyword"></a>Property `Dataset > keyword`
 
@@ -455,10 +455,10 @@ A web page that provides access to the Dataset, its Distributions and/or additio
 
 inline description of Document
 
-| **Type**                  | `object`                                                                                        |
-| ------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                |
-| **Same definition as**    | [Document](#sample_items_accessService_items_anyOf_i0_servesDataset_items_landingPage_anyOf_i1) |
+| **Type**                  | `object`                                                                               |
+| ------------------------- | -------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                       |
+| **Same definition as**    | [Document](#sample_items_accessService_items_servesDataset_items_landingPage_anyOf_i1) |
 
 ## <a name="previousVersion"></a>Property `Dataset > previousVersion`
 
@@ -488,10 +488,10 @@ reference to the previous dataset version
 
 inline description of Dataset
 
-| **Type**                  | `object`                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                          |
-| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
+| **Type**                  | `object`                                                         |
+| ------------------------- | ---------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                 |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_servesDataset_items) |
 
 ## <a name="qualifiedRelation"></a>Property `Dataset > qualifiedRelation`
 
@@ -512,10 +512,10 @@ Qualified relationship with role of the dataset with another resource
 
 Information about an item or entity that has some relationship to a dataset and the nature of the relationship
 
-| **Type**                  | `object`                                                                                               |
-| ------------------------- | ------------------------------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                                                       |
-| **Same definition as**    | [Relationship](#sample_items_accessService_items_anyOf_i0_servesDataset_items_qualifiedRelation_items) |
+| **Type**                  | `object`                                                                                      |
+| ------------------------- | --------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                              |
+| **Same definition as**    | [Relationship](#sample_items_accessService_items_servesDataset_items_qualifiedRelation_items) |
 
 ## <a name="spatialResolutionInMeters"></a>Property `Dataset > spatialResolutionInMeters`
 
@@ -800,10 +800,10 @@ List of standards to which the described Dataset conforms
 
 Information about a particular standard that another item conforms to
 
-| **Type**                  | `object`                                                                                                         |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                 |
-| **Same definition as**    | [Standard](#sample_items_accessService_items_anyOf_i0_servesDataset_items_landingPage_anyOf_i1_conformsTo_items) |
+| **Type**                  | `object`                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                        |
+| **Same definition as**    | [Standard](#sample_items_accessService_items_servesDataset_items_landingPage_anyOf_i1_conformsTo_items) |
 
 ## <a name="contributor"></a>Property `Dataset > contributor`
 
@@ -824,10 +824,10 @@ List of agents contributing to the Dataset
 
 An entity that could be involved with a resource
 
-| **Type**                  | `object`                                                                                                  |
-| ------------------------- | --------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                          |
-| **Same definition as**    | [Agent](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items_publisher_anyOf_i1) |
+| **Type**                  | `object`                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                                                                 |
+| **Same definition as**    | [Agent](#sample_items_accessService_items_servesDataset_items_inSeries_items_publisher_anyOf_i1) |
 
 ## <a name="created"></a>Property `Dataset > created`
 
@@ -928,10 +928,10 @@ An entity responsible for producing the dataset
 
 inline description of Agent
 
-| **Type**                  | `object`                                                                                                  |
-| ------------------------- | --------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                          |
-| **Same definition as**    | [Agent](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items_publisher_anyOf_i1) |
+| **Type**                  | `object`                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                                                                 |
+| **Same definition as**    | [Agent](#sample_items_accessService_items_servesDataset_items_inSeries_items_publisher_anyOf_i1) |
 
 ## <a name="description"></a>Property `Dataset > description`
 
@@ -969,10 +969,10 @@ List of related datasets that are part of the described dataset
 
 Information about a set of data
 
-| **Type**                  | `object`                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                          |
-| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
+| **Type**                  | `object`                                                         |
+| ------------------------- | ---------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                 |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_servesDataset_items) |
 
 ## <a name="identifier"></a>Property `Dataset > identifier`
 
@@ -1302,10 +1302,10 @@ List of Datasets replaced by this Dataset
 
 Information about a set of data
 
-| **Type**                  | `object`                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                          |
-| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
+| **Type**                  | `object`                                                         |
+| ------------------------- | ---------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                 |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_servesDataset_items) |
 
 ## <a name="rights"></a>Property `Dataset > rights`
 
@@ -1370,10 +1370,10 @@ List of related Datasets from which the described Dataset is derived
 
 Information about a set of data
 
-| **Type**                  | `object`                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                          |
-| **Same definition as**    | [Dataset](#sample_items_accessService_items_anyOf_i0_servesDataset_items) |
+| **Type**                  | `object`                                                         |
+| ------------------------- | ---------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                 |
+| **Same definition as**    | [Dataset](#sample_items_accessService_items_servesDataset_items) |
 
 ## <a name="spatial"></a>Property `Dataset > spatial`
 
@@ -1404,10 +1404,10 @@ A geographic region or regions that are covered by the Dataset
 
 inline description of Location
 
-| **Type**                  | `object`                                                                                                |
-| ------------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                        |
-| **Same definition as**    | [Location](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items_spatial_items) |
+| **Type**                  | `object`                                                                                       |
+| ------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                               |
+| **Same definition as**    | [Location](#sample_items_accessService_items_servesDataset_items_inSeries_items_spatial_items) |
 
 ### <a name="spatial_anyOf_i2"></a>Property `Dataset > spatial > anyOf > List of geographic regions`
 
@@ -1426,10 +1426,10 @@ inline description of Location
 
 Information about a specific geographic location
 
-| **Type**                  | `object`                                                                                                |
-| ------------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                        |
-| **Same definition as**    | [Location](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items_spatial_items) |
+| **Type**                  | `object`                                                                                       |
+| ------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                               |
+| **Same definition as**    | [Location](#sample_items_accessService_items_servesDataset_items_inSeries_items_spatial_items) |
 
 ## <a name="subject"></a>Property `Dataset > subject`
 
@@ -1474,10 +1474,10 @@ List of temporal periods that the dataset covers
 
 Information about a specific time period with a start- and/or end-time
 
-| **Type**                  | `object`                                                                                                     |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                                                             |
-| **Same definition as**    | [PeriodOfTime](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items_temporal_items) |
+| **Type**                  | `object`                                                                                            |
+| ------------------------- | --------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                    |
+| **Same definition as**    | [PeriodOfTime](#sample_items_accessService_items_servesDataset_items_inSeries_items_temporal_items) |
 
 ## <a name="title"></a>Property `Dataset > title`
 
@@ -1539,10 +1539,10 @@ List of quality measurements for the dataset
 
 A single measurement of one metric
 
-| **Type**                  | `object`                                                                                                         |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                 |
-| **Same definition as**    | [QualityMeasurement](#sample_items_accessService_items_anyOf_i0_servesDataset_items_hasQualityMeasurement_items) |
+| **Type**                  | `object`                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                        |
+| **Same definition as**    | [QualityMeasurement](#sample_items_accessService_items_servesDataset_items_hasQualityMeasurement_items) |
 
 ## <a name="page"></a>Property `Dataset > page`
 
@@ -1563,10 +1563,10 @@ List of pages or documents about this dataset
 
 Information about a text document
 
-| **Type**                  | `object`                                                                                        |
-| ------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                |
-| **Same definition as**    | [Document](#sample_items_accessService_items_anyOf_i0_servesDataset_items_landingPage_anyOf_i1) |
+| **Type**                  | `object`                                                                               |
+| ------------------------- | -------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                       |
+| **Same definition as**    | [Document](#sample_items_accessService_items_servesDataset_items_landingPage_anyOf_i1) |
 
 ## <a name="qualifiedAttribution"></a>Property `Dataset > qualifiedAttribution`
 
@@ -1587,10 +1587,10 @@ List of agents having some form of responsibility for the dataset
 
 An attribution that an agent plays some role
 
-| **Type**                  | `object`                                                                                                 |
-| ------------------------- | -------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                         |
-| **Same definition as**    | [Attribution](#sample_items_accessService_items_anyOf_i0_servesDataset_items_qualifiedAttribution_items) |
+| **Type**                  | `object`                                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                |
+| **Same definition as**    | [Attribution](#sample_items_accessService_items_servesDataset_items_qualifiedAttribution_items) |
 
 ## <a name="wasAttributedTo"></a>Property `Dataset > wasAttributedTo`
 
@@ -1611,10 +1611,10 @@ List of agents attributed to this dataset
 
 An entity that could be involved with a resource
 
-| **Type**                  | `object`                                                                                                  |
-| ------------------------- | --------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                          |
-| **Same definition as**    | [Agent](#sample_items_accessService_items_anyOf_i0_servesDataset_items_inSeries_items_publisher_anyOf_i1) |
+| **Type**                  | `object`                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                                                                 |
+| **Same definition as**    | [Agent](#sample_items_accessService_items_servesDataset_items_inSeries_items_publisher_anyOf_i1) |
 
 ## <a name="wasGeneratedBy"></a>Property `Dataset > wasGeneratedBy`
 
@@ -1635,10 +1635,10 @@ List of activities that generated, or provide the business context for the creat
 
 An activity which a resource could be related to
 
-| **Type**                  | `object`                                                                                        |
-| ------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                |
-| **Same definition as**    | [Activity](#sample_items_accessService_items_anyOf_i0_servesDataset_items_wasGeneratedBy_items) |
+| **Type**                  | `object`                                                                               |
+| ------------------------- | -------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                       |
+| **Same definition as**    | [Activity](#sample_items_accessService_items_servesDataset_items_wasGeneratedBy_items) |
 
 ## <a name="wasUsedBy"></a>Property `Dataset > wasUsedBy`
 
@@ -1659,10 +1659,10 @@ List of activities that used the Dataset
 
 An activity which a resource could be related to
 
-| **Type**                  | `object`                                                                                        |
-| ------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                |
-| **Same definition as**    | [Activity](#sample_items_accessService_items_anyOf_i0_servesDataset_items_wasGeneratedBy_items) |
+| **Type**                  | `object`                                                                               |
+| ------------------------- | -------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                       |
+| **Same definition as**    | [Activity](#sample_items_accessService_items_servesDataset_items_wasGeneratedBy_items) |
 
 ## <a name="image"></a>Property `Dataset > image`
 

--- a/jsonschema/docs/DatasetSeries.md
+++ b/jsonschema/docs/DatasetSeries.md
@@ -422,10 +422,10 @@ An entity (organization) responsible for ensuring the coherency of the Dataset S
 
 inline description of publisher
 
-| **Type**                  | `object`                                                                         |
-| ------------------------- | -------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                 |
-| **Same definition as**    | [Agent](#first_anyOf_i1_sample_items_accessService_items_anyOf_i0_creator_items) |
+| **Type**                  | `object`                                                                |
+| ------------------------- | ----------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                        |
+| **Same definition as**    | [Agent](#first_anyOf_i1_sample_items_accessService_items_creator_items) |
 
 ## <a name="spatial"></a>Property `DatasetSeries > spatial`
 
@@ -446,10 +446,10 @@ A geographic region that is covered by the Dataset Series
 
 Information about a specific geographic location
 
-| **Type**                  | `object`                                                                            |
-| ------------------------- | ----------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                    |
-| **Same definition as**    | [Location](#first_anyOf_i1_sample_items_accessService_items_anyOf_i0_spatial_items) |
+| **Type**                  | `object`                                                                   |
+| ------------------------- | -------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                           |
+| **Same definition as**    | [Location](#first_anyOf_i1_sample_items_accessService_items_spatial_items) |
 
 ## <a name="temporal"></a>Property `DatasetSeries > temporal`
 
@@ -470,10 +470,10 @@ A list of temporal periods that the Dataset Series covers
 
 Information about a specific time period with a start- and/or end-time
 
-| **Type**                  | `object`                                                                                 |
-| ------------------------- | ---------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                         |
-| **Same definition as**    | [PeriodOfTime](#first_anyOf_i1_sample_items_accessService_items_anyOf_i0_temporal_items) |
+| **Type**                  | `object`                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                |
+| **Same definition as**    | [PeriodOfTime](#first_anyOf_i1_sample_items_accessService_items_temporal_items) |
 
 ## <a name="title"></a>Property `DatasetSeries > title`
 

--- a/jsonschema/docs/DatasetSeries.md
+++ b/jsonschema/docs/DatasetSeries.md
@@ -48,43 +48,20 @@ List of contacts that can be used for sending comments about the Dataset Series
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be            | Description |
-| ------------------------------------------ | ----------- |
-| [Kind object or link](#contactPoint_items) | -           |
+| Each item of this array must be | Description                                     |
+| ------------------------------- | ----------------------------------------------- |
+| [Kind](#contactPoint_items)     | Contact information for an individual or entity |
 
-### <a name="contactPoint_items"></a>DatasetSeries > contactPoint > Kind object or link
-
-**Title:** Kind object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                       |
-| ------------------------------------ |
-| [Kind](#contactPoint_items_anyOf_i0) |
-| [Link](#contactPoint_items_anyOf_i1) |
-
-#### <a name="contactPoint_items_anyOf_i0"></a>Property `DatasetSeries > contactPoint > Kind object or link > anyOf > Kind`
+### <a name="contactPoint_items"></a>DatasetSeries > contactPoint > Kind
 
 **Title:** Kind
 
-inline description of the contact
+Contact information for an individual or entity
 
 | **Type**                  | `object`          |
 | ------------------------- | ----------------- |
 | **Additional properties** | Any type allowed  |
 | **Defined in**            | [Kind](./Kind.md) |
-
-#### <a name="contactPoint_items_anyOf_i1"></a>Property `DatasetSeries > contactPoint > Kind object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the contact
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="first"></a>Property `DatasetSeries > first`
 
@@ -100,7 +77,6 @@ The first dataset in an ordered dataset series
 | ------------------------------------------------- |
 | [Null allowed when not required](#first_anyOf_i0) |
 | [Dataset](#first_anyOf_i1)                        |
-| [Link](#first_anyOf_i2)                           |
 
 ### <a name="first_anyOf_i0"></a>Property `DatasetSeries > first > anyOf > Null allowed when not required`
 
@@ -120,16 +96,6 @@ inline description of the first dataset
 | **Additional properties** | Any type allowed        |
 | **Defined in**            | [Dataset](./Dataset.md) |
 
-### <a name="first_anyOf_i2"></a>Property `DatasetSeries > first > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the first dataset
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
 ## <a name="last"></a>Property `DatasetSeries > last`
 
 **Title:** last
@@ -144,7 +110,6 @@ The last dataset in an ordered dataset series
 | ------------------------------------------------ |
 | [Null allowed when not required](#last_anyOf_i0) |
 | [Dataset](#last_anyOf_i1)                        |
-| [Link](#last_anyOf_i2)                           |
 
 ### <a name="last_anyOf_i0"></a>Property `DatasetSeries > last > anyOf > Null allowed when not required`
 
@@ -164,16 +129,6 @@ inline description of the last dataset
 | **Additional properties** | Any type allowed           |
 | **Same definition as**    | [Dataset](#first_anyOf_i1) |
 
-### <a name="last_anyOf_i2"></a>Property `DatasetSeries > last > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the last dataset
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
 ## <a name="seriesMember"></a>Property `DatasetSeries > seriesMember`
 
 **Title:** series member
@@ -183,43 +138,20 @@ List of members of the Dataset Series
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be               | Description |
-| --------------------------------------------- | ----------- |
-| [Dataset object or link](#seriesMember_items) | -           |
+| Each item of this array must be | Description                     |
+| ------------------------------- | ------------------------------- |
+| [Dataset](#seriesMember_items)  | Information about a set of data |
 
-### <a name="seriesMember_items"></a>DatasetSeries > seriesMember > Dataset object or link
-
-**Title:** Dataset object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                          |
-| --------------------------------------- |
-| [Dataset](#seriesMember_items_anyOf_i0) |
-| [Link](#seriesMember_items_anyOf_i1)    |
-
-#### <a name="seriesMember_items_anyOf_i0"></a>Property `DatasetSeries > seriesMember > Dataset object or link > anyOf > Dataset`
+### <a name="seriesMember_items"></a>DatasetSeries > seriesMember > Dataset
 
 **Title:** Dataset
 
-inline description of the member dataset
+Information about a set of data
 
 | **Type**                  | `object`                   |
 | ------------------------- | -------------------------- |
 | **Additional properties** | Any type allowed           |
 | **Same definition as**    | [Dataset](#first_anyOf_i1) |
-
-#### <a name="seriesMember_items_anyOf_i1"></a>Property `DatasetSeries > seriesMember > Dataset object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the member dataset
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="accrualPeriodicity"></a>Property `DatasetSeries > accrualPeriodicity`
 
@@ -476,7 +408,6 @@ An entity (organization) responsible for ensuring the coherency of the Dataset S
 | ----------------------------------------------------- |
 | [Null allowed when not required](#publisher_anyOf_i0) |
 | [Agent](#publisher_anyOf_i1)                          |
-| [Link](#publisher_anyOf_i2)                           |
 
 ### <a name="publisher_anyOf_i0"></a>Property `DatasetSeries > publisher > anyOf > Null allowed when not required`
 
@@ -491,20 +422,10 @@ An entity (organization) responsible for ensuring the coherency of the Dataset S
 
 inline description of publisher
 
-| **Type**                  | `object`                                                                                           |
-| ------------------------- | -------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                   |
-| **Same definition as**    | [Agent](#first_anyOf_i1_sample_items_anyOf_i0_accessService_items_anyOf_i0_creator_items_anyOf_i0) |
-
-### <a name="publisher_anyOf_i2"></a>Property `DatasetSeries > publisher > anyOf > Link`
-
-**Title:** Link
-
-reference iri of publisher
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                         |
+| ------------------------- | -------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                 |
+| **Same definition as**    | [Agent](#first_anyOf_i1_sample_items_accessService_items_anyOf_i0_creator_items) |
 
 ## <a name="spatial"></a>Property `DatasetSeries > spatial`
 
@@ -515,43 +436,20 @@ A geographic region that is covered by the Dataset Series
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be           | Description |
-| ----------------------------------------- | ----------- |
-| [Location object or link](#spatial_items) | -           |
+| Each item of this array must be | Description                                      |
+| ------------------------------- | ------------------------------------------------ |
+| [Location](#spatial_items)      | Information about a specific geographic location |
 
-### <a name="spatial_items"></a>DatasetSeries > spatial > Location object or link
-
-**Title:** Location object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Location](#spatial_items_anyOf_i0) |
-| [Link](#spatial_items_anyOf_i1)     |
-
-#### <a name="spatial_items_anyOf_i0"></a>Property `DatasetSeries > spatial > Location object or link > anyOf > Location`
+### <a name="spatial_items"></a>DatasetSeries > spatial > Location
 
 **Title:** Location
 
-inline description of Location
+Information about a specific geographic location
 
-| **Type**                  | `object`                                                                                              |
-| ------------------------- | ----------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                      |
-| **Same definition as**    | [Location](#first_anyOf_i1_sample_items_anyOf_i0_accessService_items_anyOf_i0_spatial_items_anyOf_i0) |
-
-#### <a name="spatial_items_anyOf_i1"></a>Property `DatasetSeries > spatial > Location object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Location
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                            |
+| ------------------------- | ----------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                    |
+| **Same definition as**    | [Location](#first_anyOf_i1_sample_items_accessService_items_anyOf_i0_spatial_items) |
 
 ## <a name="temporal"></a>Property `DatasetSeries > temporal`
 
@@ -562,43 +460,20 @@ A list of temporal periods that the Dataset Series covers
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [PeriodOfTime object or link](#temporal_items) | -           |
+| Each item of this array must be | Description                                                            |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| [PeriodOfTime](#temporal_items) | Information about a specific time period with a start- and/or end-time |
 
-### <a name="temporal_items"></a>DatasetSeries > temporal > PeriodOfTime object or link
-
-**Title:** PeriodOfTime object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                           |
-| ---------------------------------------- |
-| [PeriodOfTime](#temporal_items_anyOf_i0) |
-| [Link](#temporal_items_anyOf_i1)         |
-
-#### <a name="temporal_items_anyOf_i0"></a>Property `DatasetSeries > temporal > PeriodOfTime object or link > anyOf > PeriodOfTime`
+### <a name="temporal_items"></a>DatasetSeries > temporal > PeriodOfTime
 
 **Title:** PeriodOfTime
 
-inline description of PeriodOfTime
+Information about a specific time period with a start- and/or end-time
 
-| **Type**                  | `object`                                                                                                   |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                           |
-| **Same definition as**    | [PeriodOfTime](#first_anyOf_i1_sample_items_anyOf_i0_accessService_items_anyOf_i0_temporal_items_anyOf_i0) |
-
-#### <a name="temporal_items_anyOf_i1"></a>Property `DatasetSeries > temporal > PeriodOfTime object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of PeriodOfTime
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                 |
+| ------------------------- | ---------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                         |
+| **Same definition as**    | [PeriodOfTime](#first_anyOf_i1_sample_items_accessService_items_anyOf_i0_temporal_items) |
 
 ## <a name="title"></a>Property `DatasetSeries > title`
 

--- a/jsonschema/docs/Distribution.md
+++ b/jsonschema/docs/Distribution.md
@@ -8,45 +8,45 @@ A file that distributes the dataset
 | ------------------------- | ---------------- |
 | **Additional properties** | Any type allowed |
 
-| Property                                                   | Type               | Title/Description                                                                   |
-| ---------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------- |
-| - [@id](#@id )                                             | string             | -                                                                                   |
-| - [@type](#@type )                                         | string             | -                                                                                   |
-| - [representationTechnique](#representationTechnique )     | More than one type | representation technique                                                            |
-| - [status](#status )                                       | More than one type | lifecycle status                                                                    |
-| - [characterEncoding](#characterEncoding )                 | More than one type | character encoding                                                                  |
-| - [accessService](#accessService )                         | null or array      | access service                                                                      |
-| - [accessURL](#accessURL )                                 | More than one type | access URL                                                                          |
-| - [byteSize](#byteSize )                                   | null or string     | byte size                                                                           |
-| - [compressFormat](#compressFormat )                       | null or string     | compression format                                                                  |
-| - [downloadURL](#downloadURL )                             | More than one type | download URL                                                                        |
-| - [mediaType](#mediaType )                                 | null or string     | media type                                                                          |
-| - [packageFormat](#packageFormat )                         | null or string     | packaging format                                                                    |
-| - [spatialResolutionInMeters](#spatialResolutionInMeters ) | null or string     | Spatial resolution (meters)                                                         |
-| - [temporalResolution](#temporalResolution )               | null or string     | termporal resolution                                                                |
-| - [availability](#availability )                           | More than one type | availability                                                                        |
-| - [accessRestriction](#accessRestriction )                 | null or array      | access restriction                                                                  |
-| - [cuiRestriction](#cuiRestriction )                       | More than one type | CUI restriction                                                                     |
-| - [describedBy](#describedBy )                             | More than one type | data dictionary                                                                     |
-| - [useRestriction](#useRestriction )                       | null or array      | use restriction                                                                     |
-| - [accessRights](#accessRights )                           | More than one type | access rights                                                                       |
-| - [conformsTo](#conformsTo )                               | null or array      | linked schemas                                                                      |
-| - [description](#description )                             | null or string     | description                                                                         |
-| - [descriptionMap](#descriptionMap )                       | null or object     | Language map for description. E.g. {'es': 'spanish words', 'fr': 'french words'}    |
-| - [format](#format )                                       | null or string     | format                                                                              |
-| - [identifier](#identifier )                               | More than one type | identifier                                                                          |
-| - [otherIdentifier](#otherIdentifier )                     | null or array      | other identifier                                                                    |
-| - [issued](#issued )                                       | More than one type | release date                                                                        |
-| - [language](#language )                                   | More than one type | language                                                                            |
-| - [license](#license )                                     | More than one type | license                                                                             |
-| - [modified](#modified )                                   | More than one type | last modified                                                                       |
-| - [rights](#rights )                                       | null or array      | rights                                                                              |
-| - [title](#title )                                         | null or string     | title                                                                               |
-| - [titleMap](#titleMap )                                   | null or object     | Language map for property title. E.g. {'es': 'spanish words', 'fr': 'french words'} |
-| - [hasQualityMeasurement](#hasQualityMeasurement )         | null or array      | quality measurement                                                                 |
-| - [page](#page )                                           | null or array      | documentation                                                                       |
-| - [image](#image )                                         | More than one type | image                                                                               |
-| - [checksum](#checksum )                                   | More than one type | checksum                                                                            |
+| Property                                                   | Type                    | Title/Description                                                                   |
+| ---------------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------- |
+| - [@id](#@id )                                             | string                  | -                                                                                   |
+| - [@type](#@type )                                         | string                  | -                                                                                   |
+| - [representationTechnique](#representationTechnique )     | More than one type      | representation technique                                                            |
+| - [status](#status )                                       | More than one type      | lifecycle status                                                                    |
+| - [characterEncoding](#characterEncoding )                 | More than one type      | character encoding                                                                  |
+| - [accessService](#accessService )                         | null or array           | access service                                                                      |
+| - [accessURL](#accessURL )                                 | More than one type      | access URL                                                                          |
+| - [byteSize](#byteSize )                                   | null or string          | byte size                                                                           |
+| - [compressFormat](#compressFormat )                       | null or string          | compression format                                                                  |
+| - [downloadURL](#downloadURL )                             | More than one type      | download URL                                                                        |
+| - [mediaType](#mediaType )                                 | null or string          | media type                                                                          |
+| - [packageFormat](#packageFormat )                         | null or string          | packaging format                                                                    |
+| - [spatialResolutionInMeters](#spatialResolutionInMeters ) | null or string          | Spatial resolution (meters)                                                         |
+| - [temporalResolution](#temporalResolution )               | null or string          | termporal resolution                                                                |
+| - [availability](#availability )                           | More than one type      | availability                                                                        |
+| - [accessRestriction](#accessRestriction )                 | null or array           | access restriction                                                                  |
+| - [cuiRestriction](#cuiRestriction )                       | More than one type      | CUI restriction                                                                     |
+| - [describedBy](#describedBy )                             | More than one type      | data dictionary                                                                     |
+| - [useRestriction](#useRestriction )                       | null or array           | use restriction                                                                     |
+| - [accessRights](#accessRights )                           | More than one type      | access rights                                                                       |
+| - [conformsTo](#conformsTo )                               | null or array           | linked schemas                                                                      |
+| - [description](#description )                             | null or string          | description                                                                         |
+| - [descriptionMap](#descriptionMap )                       | null or object          | Language map for description. E.g. {'es': 'spanish words', 'fr': 'french words'}    |
+| - [format](#format )                                       | null or string          | format                                                                              |
+| - [identifier](#identifier )                               | More than one type      | identifier                                                                          |
+| - [otherIdentifier](#otherIdentifier )                     | null or array           | other identifier                                                                    |
+| - [issued](#issued )                                       | More than one type      | release date                                                                        |
+| - [language](#language )                                   | More than one type      | language                                                                            |
+| - [license](#license )                                     | More than one type      | license                                                                             |
+| - [modified](#modified )                                   | More than one type      | last modified                                                                       |
+| - [rights](#rights )                                       | null or array of string | rights                                                                              |
+| - [title](#title )                                         | null or string          | title                                                                               |
+| - [titleMap](#titleMap )                                   | null or object          | Language map for property title. E.g. {'es': 'spanish words', 'fr': 'french words'} |
+| - [hasQualityMeasurement](#hasQualityMeasurement )         | null or array           | quality measurement                                                                 |
+| - [page](#page )                                           | null or array           | documentation                                                                       |
+| - [image](#image )                                         | More than one type      | image                                                                               |
+| - [checksum](#checksum )                                   | More than one type      | checksum                                                                            |
 
 ## <a name="@id"></a>Property `Distribution > @id`
 
@@ -74,7 +74,6 @@ The format in which an Distribution is released. This is different from the file
 | ------------------------------------------------------------------- |
 | [Null allowed when not required](#representationTechnique_anyOf_i0) |
 | [Concept](#representationTechnique_anyOf_i1)                        |
-| [Link](#representationTechnique_anyOf_i2)                           |
 
 ### <a name="representationTechnique_anyOf_i0"></a>Property `Distribution > representationTechnique > anyOf > Null allowed when not required`
 
@@ -94,16 +93,6 @@ inline description of Concept
 | **Additional properties** | Any type allowed        |
 | **Defined in**            | [Concept](./Concept.md) |
 
-### <a name="representationTechnique_anyOf_i2"></a>Property `Distribution > representationTechnique > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
 ## <a name="status"></a>Property `Distribution > status`
 
 **Title:** lifecycle status
@@ -118,7 +107,6 @@ The status of the distribution in the context of maturity lifecycle
 | -------------------------------------------------- |
 | [Null allowed when not required](#status_anyOf_i0) |
 | [Concept](#status_anyOf_i1)                        |
-| [Link](#status_anyOf_i2)                           |
 
 ### <a name="status_anyOf_i0"></a>Property `Distribution > status > anyOf > Null allowed when not required`
 
@@ -137,16 +125,6 @@ inline description of Concept
 | ------------------------- | -------------------------------------------- |
 | **Additional properties** | Any type allowed                             |
 | **Same definition as**    | [Concept](#representationTechnique_anyOf_i1) |
-
-### <a name="status_anyOf_i2"></a>Property `Distribution > status > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="characterEncoding"></a>Property `Distribution > characterEncoding`
 
@@ -212,7 +190,6 @@ A data service that gives access to the distribution of the dataset
 | Any of(Option)                               |
 | -------------------------------------------- |
 | [DataService](#accessService_items_anyOf_i0) |
-| [Link](#accessService_items_anyOf_i1)        |
 
 #### <a name="accessService_items_anyOf_i0"></a>Property `Distribution > accessService > DataService object or link > anyOf > DataService`
 
@@ -224,16 +201,6 @@ inline description of DataService
 | ------------------------- | ------------------------------- |
 | **Additional properties** | Any type allowed                |
 | **Defined in**            | [Dataservice](./Dataservice.md) |
-
-#### <a name="accessService_items_anyOf_i1"></a>Property `Distribution > accessService > DataService object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of DataService
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="accessURL"></a>Property `Distribution > accessURL`
 
@@ -367,7 +334,6 @@ An indication how long it is planned to keep the Distribution of the Dataset ava
 | -------------------------------------------------------- |
 | [Null allowed when not required](#availability_anyOf_i0) |
 | [Concept](#availability_anyOf_i1)                        |
-| [Link](#availability_anyOf_i2)                           |
 
 ### <a name="availability_anyOf_i0"></a>Property `Distribution > availability > anyOf > Null allowed when not required`
 
@@ -387,16 +353,6 @@ inline description of Concept
 | **Additional properties** | Any type allowed                             |
 | **Same definition as**    | [Concept](#representationTechnique_anyOf_i1) |
 
-### <a name="availability_anyOf_i2"></a>Property `Distribution > availability > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
 ## <a name="accessRestriction"></a>Property `Distribution > accessRestriction`
 
 **Title:** access restriction
@@ -406,43 +362,20 @@ List of access restrictions related to the distribution
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                              | Description |
-| ------------------------------------------------------------ | ----------- |
-| [AccessRestriction object or link](#accessRestriction_items) | -           |
+| Each item of this array must be               | Description                                         |
+| --------------------------------------------- | --------------------------------------------------- |
+| [AccessRestriction](#accessRestriction_items) | A restriction on the permitted access to a resource |
 
-### <a name="accessRestriction_items"></a>Distribution > accessRestriction > AccessRestriction object or link
-
-**Title:** AccessRestriction object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                         |
-| ------------------------------------------------------ |
-| [AccessRestriction](#accessRestriction_items_anyOf_i0) |
-| [Link](#accessRestriction_items_anyOf_i1)              |
-
-#### <a name="accessRestriction_items_anyOf_i0"></a>Property `Distribution > accessRestriction > AccessRestriction object or link > anyOf > AccessRestriction`
+### <a name="accessRestriction_items"></a>Distribution > accessRestriction > AccessRestriction
 
 **Title:** AccessRestriction
 
-inline description of AccessRestriction
+A restriction on the permitted access to a resource
 
-| **Type**                  | `object`                                                                                                                               |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                                       |
-| **Same definition as**    | [AccessRestriction](#accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_sample_items_anyOf_i0_accessRestriction_items_anyOf_i0) |
-
-#### <a name="accessRestriction_items_anyOf_i1"></a>Property `Distribution > accessRestriction > AccessRestriction object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of AccessRestriction
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                                    |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                            |
+| **Same definition as**    | [AccessRestriction](#accessService_items_anyOf_i0_servesDataset_items_sample_items_accessRestriction_items) |
 
 ## <a name="cuiRestriction"></a>Property `Distribution > cuiRestriction`
 
@@ -458,7 +391,6 @@ Controlled Unclassified Information restriction related to the distribution
 | ---------------------------------------------------------- |
 | [Null allowed when not required](#cuiRestriction_anyOf_i0) |
 | [CUIRestriction](#cuiRestriction_anyOf_i1)                 |
-| [Link](#cuiRestriction_anyOf_i2)                           |
 
 ### <a name="cuiRestriction_anyOf_i0"></a>Property `Distribution > cuiRestriction > anyOf > Null allowed when not required`
 
@@ -473,20 +405,10 @@ Controlled Unclassified Information restriction related to the distribution
 
 inline description of CUIRestriction
 
-| **Type**                  | `object`                                                                                                                   |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                           |
-| **Same definition as**    | [CUIRestriction](#accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_sample_items_anyOf_i0_cuiRestriction_anyOf_i1) |
-
-### <a name="cuiRestriction_anyOf_i2"></a>Property `Distribution > cuiRestriction > anyOf > Link`
-
-**Title:** Link
-
-reference iri of CUIRestriction
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                                 |
+| ------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                         |
+| **Same definition as**    | [CUIRestriction](#accessService_items_anyOf_i0_servesDataset_items_sample_items_cuiRestriction_anyOf_i1) |
 
 ## <a name="describedBy"></a>Property `Distribution > describedBy`
 
@@ -502,7 +424,6 @@ A distribution containing the Data Dictionary for this distribution
 | ------------------------------------------------------- |
 | [Null allowed when not required](#describedBy_anyOf_i0) |
 | [Distribution](#describedBy_anyOf_i1)                   |
-| [Link](#describedBy_anyOf_i2)                           |
 
 ### <a name="describedBy_anyOf_i0"></a>Property `Distribution > describedBy > anyOf > Null allowed when not required`
 
@@ -517,20 +438,10 @@ A distribution containing the Data Dictionary for this distribution
 
 inline description of the data dictionary
 
-| **Type**                  | `object`                                                                                         |
-| ------------------------- | ------------------------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                                                 |
-| **Same definition as**    | [Distribution](#accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_sample_items_anyOf_i0) |
-
-### <a name="describedBy_anyOf_i2"></a>Property `Distribution > describedBy > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the data dictionary
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------ |
+| **Additional properties** | Any type allowed                                                               |
+| **Same definition as**    | [Distribution](#accessService_items_anyOf_i0_servesDataset_items_sample_items) |
 
 ## <a name="useRestriction"></a>Property `Distribution > useRestriction`
 
@@ -541,43 +452,20 @@ Use restriction related to the distribution
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                        | Description |
-| ------------------------------------------------------ | ----------- |
-| [UseRestriction object or link](#useRestriction_items) | -           |
+| Each item of this array must be         | Description                            |
+| --------------------------------------- | -------------------------------------- |
+| [UseRestriction](#useRestriction_items) | A restriction on usage of another item |
 
-### <a name="useRestriction_items"></a>Distribution > useRestriction > UseRestriction object or link
-
-**Title:** UseRestriction object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                   |
-| ------------------------------------------------ |
-| [UseRestriction](#useRestriction_items_anyOf_i0) |
-| [Link](#useRestriction_items_anyOf_i1)           |
-
-#### <a name="useRestriction_items_anyOf_i0"></a>Property `Distribution > useRestriction > UseRestriction object or link > anyOf > UseRestriction`
+### <a name="useRestriction_items"></a>Distribution > useRestriction > UseRestriction
 
 **Title:** UseRestriction
 
-inline description of UseRestriction
+A restriction on usage of another item
 
-| **Type**                  | `object`                                                                                                                         |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                                 |
-| **Same definition as**    | [UseRestriction](#accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_sample_items_anyOf_i0_useRestriction_items_anyOf_i0) |
-
-#### <a name="useRestriction_items_anyOf_i1"></a>Property `Distribution > useRestriction > UseRestriction object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of UseRestriction
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                              |
+| ------------------------- | ----------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                      |
+| **Same definition as**    | [UseRestriction](#accessService_items_anyOf_i0_servesDataset_items_sample_items_useRestriction_items) |
 
 ## <a name="accessRights"></a>Property `Distribution > accessRights`
 
@@ -593,7 +481,6 @@ Information that indicates whether the Distribution is open data, has access res
 | -------------------------------------------------------- |
 | [Null allowed when not required](#accessRights_anyOf_i0) |
 | [item 1](#accessRights_anyOf_i1)                         |
-| [Link](#accessRights_anyOf_i2)                           |
 
 ### <a name="accessRights_anyOf_i0"></a>Property `Distribution > accessRights > anyOf > Null allowed when not required`
 
@@ -609,16 +496,6 @@ Text description of the access rights
 | **Type** | `string` |
 | -------- | -------- |
 
-### <a name="accessRights_anyOf_i2"></a>Property `Distribution > accessRights > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the access rights
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
 ## <a name="conformsTo"></a>Property `Distribution > conformsTo`
 
 **Title:** linked schemas
@@ -628,43 +505,20 @@ List of established schemas or reference systems to which the described Distribu
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be              | Description |
-| -------------------------------------------- | ----------- |
-| [Standard object or link](#conformsTo_items) | -           |
+| Each item of this array must be | Description                                                           |
+| ------------------------------- | --------------------------------------------------------------------- |
+| [Standard](#conformsTo_items)   | Information about a particular standard that another item conforms to |
 
-### <a name="conformsTo_items"></a>Distribution > conformsTo > Standard object or link
-
-**Title:** Standard object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                         |
-| -------------------------------------- |
-| [Standard](#conformsTo_items_anyOf_i0) |
-| [Link](#conformsTo_items_anyOf_i1)     |
-
-#### <a name="conformsTo_items_anyOf_i0"></a>Property `Distribution > conformsTo > Standard object or link > anyOf > Standard`
+### <a name="conformsTo_items"></a>Distribution > conformsTo > Standard
 
 **Title:** Standard
 
-inline description of Standard
+Information about a particular standard that another item conforms to
 
-| **Type**                  | `object`                                                                                                               |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                       |
-| **Same definition as**    | [Standard](#accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_sample_items_anyOf_i0_conformsTo_items_anyOf_i0) |
-
-#### <a name="conformsTo_items_anyOf_i1"></a>Property `Distribution > conformsTo > Standard object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Standard
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                            |
+| **Same definition as**    | [Standard](#accessService_items_anyOf_i0_servesDataset_items_sample_items_conformsTo_items) |
 
 ## <a name="description"></a>Property `Distribution > description`
 
@@ -705,7 +559,6 @@ The unique identifier for the Distribution (e.g. DOI, ISBN)
 | ------------------------------------------------------ |
 | [Null allowed when not required](#identifier_anyOf_i0) |
 | [Identifier](#identifier_anyOf_i1)                     |
-| [Link](#identifier_anyOf_i2)                           |
 
 ### <a name="identifier_anyOf_i0"></a>Property `Distribution > identifier > anyOf > Null allowed when not required`
 
@@ -720,20 +573,10 @@ The unique identifier for the Distribution (e.g. DOI, ISBN)
 
 inline description of Identifier
 
-| **Type**                  | More than one type                                                                                      |
-| ------------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                        |
-| **Same definition as**    | [Identifier](#accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_otherIdentifier_items_anyOf_i0) |
-
-### <a name="identifier_anyOf_i2"></a>Property `Distribution > identifier > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                      |
+| **Same definition as**    | [Identifier](#accessService_items_anyOf_i0_servesDataset_items_otherIdentifier_items) |
 
 ## <a name="otherIdentifier"></a>Property `Distribution > otherIdentifier`
 
@@ -744,43 +587,20 @@ A list of identifiers for the Distribution besides the main identifier, e.g. the
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                     | Description |
-| --------------------------------------------------- | ----------- |
-| [Identifier object or link](#otherIdentifier_items) | -           |
+| Each item of this array must be      | Description                                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------- |
+| [Identifier](#otherIdentifier_items) | A unique identifier and optionally it's scheme and other relevant information |
 
-### <a name="otherIdentifier_items"></a>Distribution > otherIdentifier > Identifier object or link
-
-**Title:** Identifier object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                |
-| --------------------------------------------- |
-| [Identifier](#otherIdentifier_items_anyOf_i0) |
-| [Link](#otherIdentifier_items_anyOf_i1)       |
-
-#### <a name="otherIdentifier_items_anyOf_i0"></a>Property `Distribution > otherIdentifier > Identifier object or link > anyOf > Identifier`
+### <a name="otherIdentifier_items"></a>Distribution > otherIdentifier > Identifier
 
 **Title:** Identifier
 
-inline description of Identifier
+A unique identifier and optionally it's scheme and other relevant information
 
-| **Type**                  | More than one type                                                                                      |
-| ------------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                        |
-| **Same definition as**    | [Identifier](#accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_otherIdentifier_items_anyOf_i0) |
-
-#### <a name="otherIdentifier_items_anyOf_i1"></a>Property `Distribution > otherIdentifier > Identifier object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                      |
+| **Same definition as**    | [Identifier](#accessService_items_anyOf_i0_servesDataset_items_otherIdentifier_items) |
 
 ## <a name="issued"></a>Property `Distribution > issued`
 
@@ -923,7 +743,6 @@ The license under which the Distribution is made available; see https://resource
 | --------------------------------------------------- |
 | [Null allowed when not required](#license_anyOf_i0) |
 | [item 1](#license_anyOf_i1)                         |
-| [Link](#license_anyOf_i2)                           |
 
 ### <a name="license_anyOf_i0"></a>Property `Distribution > license > anyOf > Null allowed when not required`
 
@@ -938,16 +757,6 @@ Full text of the license
 
 | **Type** | `string` |
 | -------- | -------- |
-
-### <a name="license_anyOf_i2"></a>Property `Distribution > license > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the license
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="modified"></a>Property `Distribution > modified`
 
@@ -1026,40 +835,19 @@ A year and month in YYYY-MM format
 
 A list of statements concerning all rights for the Distribution that may not be addressed by license or accessRights, such as copyright statements, statements about the intellectual property rights (IPR), or information regarding access or restrictions based on privacy, security, or other policies
 
-| **Type** | `null or array` |
-| -------- | --------------- |
+| **Type** | `null or array of string` |
+| -------- | ------------------------- |
 
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [Rights statement text or link](#rights_items) | -           |
+| Each item of this array must be | Description                        |
+| ------------------------------- | ---------------------------------- |
+| [rights items](#rights_items)   | Full text of a statement of rights |
 
-### <a name="rights_items"></a>Distribution > rights > Rights statement text or link
-
-**Title:** Rights statement text or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                   |
-| -------------------------------- |
-| [item 0](#rights_items_anyOf_i0) |
-| [item 1](#rights_items_anyOf_i1) |
-
-#### <a name="rights_items_anyOf_i0"></a>Property `Distribution > rights > Rights statement text or link > anyOf > item 0`
+### <a name="rights_items"></a>Distribution > rights > rights items
 
 Full text of a statement of rights
 
 | **Type** | `string` |
 | -------- | -------- |
-
-#### <a name="rights_items_anyOf_i1"></a>Property `Distribution > rights > Rights statement text or link > anyOf > item 1`
-
-reference iri of a statement of rights
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="title"></a>Property `Distribution > title`
 
@@ -1086,43 +874,20 @@ A list of quality measurements for the distribution
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                                   | Description |
-| ----------------------------------------------------------------- | ----------- |
-| [QualityMeasurement object or link](#hasQualityMeasurement_items) | -           |
+| Each item of this array must be                    | Description                        |
+| -------------------------------------------------- | ---------------------------------- |
+| [QualityMeasurement](#hasQualityMeasurement_items) | A single measurement of one metric |
 
-### <a name="hasQualityMeasurement_items"></a>Distribution > hasQualityMeasurement > QualityMeasurement object or link
-
-**Title:** QualityMeasurement object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                              |
-| ----------------------------------------------------------- |
-| [QualityMeasurement](#hasQualityMeasurement_items_anyOf_i0) |
-| [Link](#hasQualityMeasurement_items_anyOf_i1)               |
-
-#### <a name="hasQualityMeasurement_items_anyOf_i0"></a>Property `Distribution > hasQualityMeasurement > QualityMeasurement object or link > anyOf > QualityMeasurement`
+### <a name="hasQualityMeasurement_items"></a>Distribution > hasQualityMeasurement > QualityMeasurement
 
 **Title:** QualityMeasurement
 
-inline description of QualityMeasurement
+A single measurement of one metric
 
-| **Type**                  | `object`                                                                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                                            |
-| **Same definition as**    | [QualityMeasurement](#accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_sample_items_anyOf_i0_hasQualityMeasurement_items_anyOf_i0) |
-
-#### <a name="hasQualityMeasurement_items_anyOf_i1"></a>Property `Distribution > hasQualityMeasurement > QualityMeasurement object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of QualityMeasurement
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                                         |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                                 |
+| **Same definition as**    | [QualityMeasurement](#accessService_items_anyOf_i0_servesDataset_items_sample_items_hasQualityMeasurement_items) |
 
 ## <a name="page"></a>Property `Distribution > page`
 
@@ -1133,43 +898,20 @@ A page or document about this Distribution
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be        | Description |
-| -------------------------------------- | ----------- |
-| [Document object or link](#page_items) | -           |
+| Each item of this array must be | Description                       |
+| ------------------------------- | --------------------------------- |
+| [Document](#page_items)         | Information about a text document |
 
-### <a name="page_items"></a>Distribution > page > Document object or link
-
-**Title:** Document object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                   |
-| -------------------------------- |
-| [Document](#page_items_anyOf_i0) |
-| [Link](#page_items_anyOf_i1)     |
-
-#### <a name="page_items_anyOf_i0"></a>Property `Distribution > page > Document object or link > anyOf > Document`
+### <a name="page_items"></a>Distribution > page > Document
 
 **Title:** Document
 
-inline description of Document
+Information about a text document
 
-| **Type**                  | `object`                                                                                                         |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                 |
-| **Same definition as**    | [Document](#accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_sample_items_anyOf_i0_page_items_anyOf_i0) |
-
-#### <a name="page_items_anyOf_i1"></a>Property `Distribution > page > Document object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Document
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                      |
+| **Same definition as**    | [Document](#accessService_items_anyOf_i0_servesDataset_items_sample_items_page_items) |
 
 ## <a name="image"></a>Property `Distribution > image`
 
@@ -1217,7 +959,6 @@ A mechanism that can be used to verify that the contents of a distribution have 
 | ---------------------------------------------------- |
 | [Null allowed when not required](#checksum_anyOf_i0) |
 | [Checksum](#checksum_anyOf_i1)                       |
-| [Link](#checksum_anyOf_i2)                           |
 
 ### <a name="checksum_anyOf_i0"></a>Property `Distribution > checksum > anyOf > Null allowed when not required`
 
@@ -1232,18 +973,8 @@ A mechanism that can be used to verify that the contents of a distribution have 
 
 inline description of Checksum
 
-| **Type**                  | `object`                                                                                                       |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                               |
-| **Same definition as**    | [Checksum](#accessService_items_anyOf_i0_servesDataset_items_anyOf_i0_sample_items_anyOf_i0_checksum_anyOf_i1) |
-
-### <a name="checksum_anyOf_i2"></a>Property `Distribution > checksum > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Checksum
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                                     |
+| ------------------------- | -------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                             |
+| **Same definition as**    | [Checksum](#accessService_items_anyOf_i0_servesDataset_items_sample_items_checksum_anyOf_i1) |
 

--- a/jsonschema/docs/Distribution.md
+++ b/jsonschema/docs/Distribution.md
@@ -8,43 +8,43 @@ A file that distributes the dataset
 | ------------------------- | ---------------- |
 | **Additional properties** | Any type allowed |
 
-| Property                                                   | Type               | Title/Description           |
-| ---------------------------------------------------------- | ------------------ | --------------------------- |
-| - [@id](#@id )                                             | string             | -                           |
-| - [@type](#@type )                                         | string             | -                           |
-| - [representationTechnique](#representationTechnique )     | More than one type | representation technique    |
-| - [status](#status )                                       | More than one type | lifecycle status            |
-| - [characterEncoding](#characterEncoding )                 | More than one type | character encoding          |
-| - [accessService](#accessService )                         | null or array      | access service              |
-| - [accessURL](#accessURL )                                 | More than one type | access URL                  |
-| - [byteSize](#byteSize )                                   | null or string     | byte size                   |
-| - [compressFormat](#compressFormat )                       | null or string     | compression format          |
-| - [downloadURL](#downloadURL )                             | More than one type | download URL                |
-| - [mediaType](#mediaType )                                 | null or string     | media type                  |
-| - [packageFormat](#packageFormat )                         | null or string     | packaging format            |
-| - [spatialResolutionInMeters](#spatialResolutionInMeters ) | null or string     | Spatial resolution (meters) |
-| - [temporalResolution](#temporalResolution )               | null or string     | termporal resolution        |
-| - [availability](#availability )                           | More than one type | availability                |
-| - [accessRestriction](#accessRestriction )                 | null or array      | access restriction          |
-| - [cuiRestriction](#cuiRestriction )                       | More than one type | CUI restriction             |
-| - [describedBy](#describedBy )                             | More than one type | data dictionary             |
-| - [useRestriction](#useRestriction )                       | null or array      | use restriction             |
-| - [accessRights](#accessRights )                           | More than one type | access rights               |
-| - [conformsTo](#conformsTo )                               | null or array      | linked schemas              |
-| - [description](#description )                             | null or string     | description                 |
-| - [format](#format )                                       | null or string     | format                      |
-| - [identifier](#identifier )                               | More than one type | identifier                  |
-| - [otherIdentifier](#otherIdentifier )                     | null or array      | other identifier            |
-| - [issued](#issued )                                       | More than one type | release date                |
-| - [language](#language )                                   | More than one type | language                    |
-| - [license](#license )                                     | More than one type | license                     |
-| - [modified](#modified )                                   | More than one type | last modified               |
-| - [rights](#rights )                                       | null or array      | rights                      |
-| - [title](#title )                                         | null or string     | title                       |
-| - [hasQualityMeasurement](#hasQualityMeasurement )         | null or array      | quality measurement         |
-| - [page](#page )                                           | null or array      | documentation               |
-| - [image](#image )                                         | More than one type | image                       |
-| - [checksum](#checksum )                                   | More than one type | checksum                    |
+| Property                                                   | Type                    | Title/Description           |
+| ---------------------------------------------------------- | ----------------------- | --------------------------- |
+| - [@id](#@id )                                             | string                  | -                           |
+| - [@type](#@type )                                         | string                  | -                           |
+| - [representationTechnique](#representationTechnique )     | More than one type      | representation technique    |
+| - [status](#status )                                       | More than one type      | lifecycle status            |
+| - [characterEncoding](#characterEncoding )                 | More than one type      | character encoding          |
+| - [accessService](#accessService )                         | null or array           | access service              |
+| - [accessURL](#accessURL )                                 | More than one type      | access URL                  |
+| - [byteSize](#byteSize )                                   | null or string          | byte size                   |
+| - [compressFormat](#compressFormat )                       | null or string          | compression format          |
+| - [downloadURL](#downloadURL )                             | More than one type      | download URL                |
+| - [mediaType](#mediaType )                                 | null or string          | media type                  |
+| - [packageFormat](#packageFormat )                         | null or string          | packaging format            |
+| - [spatialResolutionInMeters](#spatialResolutionInMeters ) | null or string          | Spatial resolution (meters) |
+| - [temporalResolution](#temporalResolution )               | null or string          | termporal resolution        |
+| - [availability](#availability )                           | More than one type      | availability                |
+| - [accessRestriction](#accessRestriction )                 | null or array           | access restriction          |
+| - [cuiRestriction](#cuiRestriction )                       | More than one type      | CUI restriction             |
+| - [describedBy](#describedBy )                             | More than one type      | data dictionary             |
+| - [useRestriction](#useRestriction )                       | null or array           | use restriction             |
+| - [accessRights](#accessRights )                           | More than one type      | access rights               |
+| - [conformsTo](#conformsTo )                               | null or array           | linked schemas              |
+| - [description](#description )                             | null or string          | description                 |
+| - [format](#format )                                       | null or string          | format                      |
+| - [identifier](#identifier )                               | More than one type      | identifier                  |
+| - [otherIdentifier](#otherIdentifier )                     | null or array           | other identifier            |
+| - [issued](#issued )                                       | More than one type      | release date                |
+| - [language](#language )                                   | More than one type      | language                    |
+| - [license](#license )                                     | More than one type      | license                     |
+| - [modified](#modified )                                   | More than one type      | last modified               |
+| - [rights](#rights )                                       | null or array of string | rights                      |
+| - [title](#title )                                         | null or string          | title                       |
+| - [hasQualityMeasurement](#hasQualityMeasurement )         | null or array           | quality measurement         |
+| - [page](#page )                                           | null or array           | documentation               |
+| - [image](#image )                                         | More than one type      | image                       |
+| - [checksum](#checksum )                                   | More than one type      | checksum                    |
 
 ## <a name="@id"></a>Property `Distribution > @id`
 

--- a/jsonschema/docs/Distribution.md
+++ b/jsonschema/docs/Distribution.md
@@ -175,27 +175,15 @@ A data service that gives access to the distribution of the dataset
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                    | Description |
-| -------------------------------------------------- | ----------- |
-| [DataService object or link](#accessService_items) | -           |
+| Each item of this array must be     | Description                                   |
+| ----------------------------------- | --------------------------------------------- |
+| [DataService](#accessService_items) | A service for providing data at a URL or URLs |
 
-### <a name="accessService_items"></a>Distribution > accessService > DataService object or link
-
-**Title:** DataService object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                               |
-| -------------------------------------------- |
-| [DataService](#accessService_items_anyOf_i0) |
-
-#### <a name="accessService_items_anyOf_i0"></a>Property `Distribution > accessService > DataService object or link > anyOf > DataService`
+### <a name="accessService_items"></a>Distribution > accessService > DataService
 
 **Title:** DataService
 
-inline description of DataService
+A service for providing data at a URL or URLs
 
 | **Type**                  | `object`                        |
 | ------------------------- | ------------------------------- |
@@ -372,10 +360,10 @@ List of access restrictions related to the distribution
 
 A restriction on the permitted access to a resource
 
-| **Type**                  | `object`                                                                                                    |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                            |
-| **Same definition as**    | [AccessRestriction](#accessService_items_anyOf_i0_servesDataset_items_sample_items_accessRestriction_items) |
+| **Type**                  | `object`                                                                                           |
+| ------------------------- | -------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                   |
+| **Same definition as**    | [AccessRestriction](#accessService_items_servesDataset_items_sample_items_accessRestriction_items) |
 
 ## <a name="cuiRestriction"></a>Property `Distribution > cuiRestriction`
 
@@ -405,10 +393,10 @@ Controlled Unclassified Information restriction related to the distribution
 
 inline description of CUIRestriction
 
-| **Type**                  | `object`                                                                                                 |
-| ------------------------- | -------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                         |
-| **Same definition as**    | [CUIRestriction](#accessService_items_anyOf_i0_servesDataset_items_sample_items_cuiRestriction_anyOf_i1) |
+| **Type**                  | `object`                                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                |
+| **Same definition as**    | [CUIRestriction](#accessService_items_servesDataset_items_sample_items_cuiRestriction_anyOf_i1) |
 
 ## <a name="describedBy"></a>Property `Distribution > describedBy`
 
@@ -438,10 +426,10 @@ A distribution containing the Data Dictionary for this distribution
 
 inline description of the data dictionary
 
-| **Type**                  | `object`                                                                       |
-| ------------------------- | ------------------------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                                               |
-| **Same definition as**    | [Distribution](#accessService_items_anyOf_i0_servesDataset_items_sample_items) |
+| **Type**                  | `object`                                                              |
+| ------------------------- | --------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                      |
+| **Same definition as**    | [Distribution](#accessService_items_servesDataset_items_sample_items) |
 
 ## <a name="useRestriction"></a>Property `Distribution > useRestriction`
 
@@ -462,10 +450,10 @@ Use restriction related to the distribution
 
 A restriction on usage of another item
 
-| **Type**                  | `object`                                                                                              |
-| ------------------------- | ----------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                      |
-| **Same definition as**    | [UseRestriction](#accessService_items_anyOf_i0_servesDataset_items_sample_items_useRestriction_items) |
+| **Type**                  | `object`                                                                                     |
+| ------------------------- | -------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                             |
+| **Same definition as**    | [UseRestriction](#accessService_items_servesDataset_items_sample_items_useRestriction_items) |
 
 ## <a name="accessRights"></a>Property `Distribution > accessRights`
 
@@ -515,10 +503,10 @@ List of established schemas or reference systems to which the described Distribu
 
 Information about a particular standard that another item conforms to
 
-| **Type**                  | `object`                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                            |
-| **Same definition as**    | [Standard](#accessService_items_anyOf_i0_servesDataset_items_sample_items_conformsTo_items) |
+| **Type**                  | `object`                                                                           |
+| ------------------------- | ---------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                   |
+| **Same definition as**    | [Standard](#accessService_items_servesDataset_items_sample_items_conformsTo_items) |
 
 ## <a name="description"></a>Property `Distribution > description`
 
@@ -573,10 +561,10 @@ The unique identifier for the Distribution (e.g. DOI, ISBN)
 
 inline description of Identifier
 
-| **Type**                  | More than one type                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                      |
-| **Same definition as**    | [Identifier](#accessService_items_anyOf_i0_servesDataset_items_otherIdentifier_items) |
+| **Type**                  | More than one type                                                           |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                             |
+| **Same definition as**    | [Identifier](#accessService_items_servesDataset_items_otherIdentifier_items) |
 
 ## <a name="otherIdentifier"></a>Property `Distribution > otherIdentifier`
 
@@ -597,10 +585,10 @@ A list of identifiers for the Distribution besides the main identifier, e.g. the
 
 A unique identifier and optionally it's scheme and other relevant information
 
-| **Type**                  | More than one type                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                      |
-| **Same definition as**    | [Identifier](#accessService_items_anyOf_i0_servesDataset_items_otherIdentifier_items) |
+| **Type**                  | More than one type                                                           |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                             |
+| **Same definition as**    | [Identifier](#accessService_items_servesDataset_items_otherIdentifier_items) |
 
 ## <a name="issued"></a>Property `Distribution > issued`
 
@@ -884,10 +872,10 @@ A list of quality measurements for the distribution
 
 A single measurement of one metric
 
-| **Type**                  | `object`                                                                                                         |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                                                 |
-| **Same definition as**    | [QualityMeasurement](#accessService_items_anyOf_i0_servesDataset_items_sample_items_hasQualityMeasurement_items) |
+| **Type**                  | `object`                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                                        |
+| **Same definition as**    | [QualityMeasurement](#accessService_items_servesDataset_items_sample_items_hasQualityMeasurement_items) |
 
 ## <a name="page"></a>Property `Distribution > page`
 
@@ -908,10 +896,10 @@ A page or document about this Distribution
 
 Information about a text document
 
-| **Type**                  | `object`                                                                              |
-| ------------------------- | ------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                      |
-| **Same definition as**    | [Document](#accessService_items_anyOf_i0_servesDataset_items_sample_items_page_items) |
+| **Type**                  | `object`                                                                     |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                             |
+| **Same definition as**    | [Document](#accessService_items_servesDataset_items_sample_items_page_items) |
 
 ## <a name="image"></a>Property `Distribution > image`
 
@@ -973,8 +961,8 @@ A mechanism that can be used to verify that the contents of a distribution have 
 
 inline description of Checksum
 
-| **Type**                  | `object`                                                                                     |
-| ------------------------- | -------------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                             |
-| **Same definition as**    | [Checksum](#accessService_items_anyOf_i0_servesDataset_items_sample_items_checksum_anyOf_i1) |
+| **Type**                  | `object`                                                                            |
+| ------------------------- | ----------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                    |
+| **Same definition as**    | [Checksum](#accessService_items_servesDataset_items_sample_items_checksum_anyOf_i1) |
 

--- a/jsonschema/docs/Document.md
+++ b/jsonschema/docs/Document.md
@@ -116,43 +116,20 @@ The individual(s) responsible for creating the Document
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be | Description |
-| ------------------------------- | ----------- |
-| [Kind or link](#creator_items)  | -           |
+| Each item of this array must be | Description                                     |
+| ------------------------------- | ----------------------------------------------- |
+| [Kind](#creator_items)          | Contact information for an individual or entity |
 
-### <a name="creator_items"></a>Document > creator > Kind or link
-
-**Title:** Kind or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                  |
-| ------------------------------- |
-| [Kind](#creator_items_anyOf_i0) |
-| [Link](#creator_items_anyOf_i1) |
-
-#### <a name="creator_items_anyOf_i0"></a>Property `Document > creator > Kind or link > anyOf > Kind`
+### <a name="creator_items"></a>Document > creator > Kind
 
 **Title:** Kind
 
-inline description of author
+Contact information for an individual or entity
 
 | **Type**                  | `object`          |
 | ------------------------- | ----------------- |
 | **Additional properties** | Any type allowed  |
 | **Defined in**            | [Kind](./Kind.md) |
-
-#### <a name="creator_items_anyOf_i1"></a>Property `Document > creator > Kind or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of author
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="mediaType"></a>Property `Document > mediaType`
 
@@ -197,43 +174,20 @@ List of standards that the Document conforms to
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be              | Description |
-| -------------------------------------------- | ----------- |
-| [Standard object or link](#conformsTo_items) | -           |
+| Each item of this array must be | Description                                                           |
+| ------------------------------- | --------------------------------------------------------------------- |
+| [Standard](#conformsTo_items)   | Information about a particular standard that another item conforms to |
 
-### <a name="conformsTo_items"></a>Document > conformsTo > Standard object or link
-
-**Title:** Standard object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                         |
-| -------------------------------------- |
-| [Standard](#conformsTo_items_anyOf_i0) |
-| [Link](#conformsTo_items_anyOf_i1)     |
-
-#### <a name="conformsTo_items_anyOf_i0"></a>Property `Document > conformsTo > Standard object or link > anyOf > Standard`
+### <a name="conformsTo_items"></a>Document > conformsTo > Standard
 
 **Title:** Standard
 
-inline description of Standard
+Information about a particular standard that another item conforms to
 
 | **Type**                  | `object`                  |
 | ------------------------- | ------------------------- |
 | **Additional properties** | Any type allowed          |
 | **Defined in**            | [Standard](./Standard.md) |
-
-#### <a name="conformsTo_items_anyOf_i1"></a>Property `Document > conformsTo > Standard object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Standard
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="corporateCreator"></a>Property `Document > corporateCreator`
 
@@ -244,43 +198,20 @@ The corporate organization(s) responsible for creating the Document
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                 | Description |
-| ----------------------------------------------- | ----------- |
-| [Organization or link](#corporateCreator_items) | -           |
+| Each item of this array must be         | Description                                                                         |
+| --------------------------------------- | ----------------------------------------------------------------------------------- |
+| [Organization](#corporateCreator_items) | Information about an organization, including other organizations that it is part of |
 
-### <a name="corporateCreator_items"></a>Document > corporateCreator > Organization or link
-
-**Title:** Organization or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                   |
-| ------------------------------------------------ |
-| [Organization](#corporateCreator_items_anyOf_i0) |
-| [Link](#corporateCreator_items_anyOf_i1)         |
-
-#### <a name="corporateCreator_items_anyOf_i0"></a>Property `Document > corporateCreator > Organization or link > anyOf > Organization`
+### <a name="corporateCreator_items"></a>Document > corporateCreator > Organization
 
 **Title:** Organization
 
-inline description of corporate author
+Information about an organization, including other organizations that it is part of
 
-| **Type**                  | `object`                                                                                 |
-| ------------------------- | ---------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                         |
-| **Same definition as**    | [Organization](#conformsTo_items_anyOf_i0_identifier_anyOf_i1_anyOf_i1_creator_anyOf_i1) |
-
-#### <a name="corporateCreator_items_anyOf_i1"></a>Property `Document > corporateCreator > Organization or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of corporate author
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                |
+| **Same definition as**    | [Organization](#conformsTo_items_identifier_anyOf_i1_anyOf_i1_creator_anyOf_i1) |
 
 ## <a name="description"></a>Property `Document > description`
 
@@ -312,7 +243,6 @@ The unique identifier for the Document (e.g. DOI, ISBN)
 | ------------------------------------------------------ |
 | [Null allowed when not required](#identifier_anyOf_i0) |
 | [Identifier](#identifier_anyOf_i1)                     |
-| [Link](#identifier_anyOf_i2)                           |
 
 ### <a name="identifier_anyOf_i0"></a>Property `Document > identifier > anyOf > Null allowed when not required`
 
@@ -327,20 +257,10 @@ The unique identifier for the Document (e.g. DOI, ISBN)
 
 inline description of Identifier
 
-| **Type**                  | More than one type                                           |
-| ------------------------- | ------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                             |
-| **Same definition as**    | [Identifier](#conformsTo_items_anyOf_i0_identifier_anyOf_i1) |
-
-### <a name="identifier_anyOf_i2"></a>Property `Document > identifier > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                  |
+| ------------------------- | --------------------------------------------------- |
+| **Additional properties** | Any type allowed                                    |
+| **Same definition as**    | [Identifier](#conformsTo_items_identifier_anyOf_i1) |
 
 ## <a name="otherIdentifier"></a>Property `Document > otherIdentifier`
 
@@ -351,43 +271,20 @@ A list of identifiers for the Document besides the main identifier, e.g. the URI
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                     | Description |
-| --------------------------------------------------- | ----------- |
-| [Identifier object or link](#otherIdentifier_items) | -           |
+| Each item of this array must be      | Description                                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------- |
+| [Identifier](#otherIdentifier_items) | A unique identifier and optionally it's scheme and other relevant information |
 
-### <a name="otherIdentifier_items"></a>Document > otherIdentifier > Identifier object or link
-
-**Title:** Identifier object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                |
-| --------------------------------------------- |
-| [Identifier](#otherIdentifier_items_anyOf_i0) |
-| [Link](#otherIdentifier_items_anyOf_i1)       |
-
-#### <a name="otherIdentifier_items_anyOf_i0"></a>Property `Document > otherIdentifier > Identifier object or link > anyOf > Identifier`
+### <a name="otherIdentifier_items"></a>Document > otherIdentifier > Identifier
 
 **Title:** Identifier
 
-inline description of Identifier
+A unique identifier and optionally it's scheme and other relevant information
 
-| **Type**                  | More than one type                                           |
-| ------------------------- | ------------------------------------------------------------ |
-| **Additional properties** | Any type allowed                                             |
-| **Same definition as**    | [Identifier](#conformsTo_items_anyOf_i0_identifier_anyOf_i1) |
-
-#### <a name="otherIdentifier_items_anyOf_i1"></a>Property `Document > otherIdentifier > Identifier object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                                  |
+| ------------------------- | --------------------------------------------------- |
+| **Additional properties** | Any type allowed                                    |
+| **Same definition as**    | [Identifier](#conformsTo_items_identifier_anyOf_i1) |
 
 ## <a name="issued"></a>Property `Document > issued`
 
@@ -467,43 +364,20 @@ The organization(s) that published the Document
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                 | Description |
-| ----------------------------------------------- | ----------- |
-| [Organization object or link](#publisher_items) | -           |
+| Each item of this array must be  | Description                                                                         |
+| -------------------------------- | ----------------------------------------------------------------------------------- |
+| [Organization](#publisher_items) | Information about an organization, including other organizations that it is part of |
 
-### <a name="publisher_items"></a>Document > publisher > Organization object or link
-
-**Title:** Organization object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                            |
-| ----------------------------------------- |
-| [Organization](#publisher_items_anyOf_i0) |
-| [Link](#publisher_items_anyOf_i1)         |
-
-#### <a name="publisher_items_anyOf_i0"></a>Property `Document > publisher > Organization object or link > anyOf > Organization`
+### <a name="publisher_items"></a>Document > publisher > Organization
 
 **Title:** Organization
 
-inline description of publisher
+Information about an organization, including other organizations that it is part of
 
-| **Type**                  | `object`                                                                                 |
-| ------------------------- | ---------------------------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                                         |
-| **Same definition as**    | [Organization](#conformsTo_items_anyOf_i0_identifier_anyOf_i1_anyOf_i1_creator_anyOf_i1) |
-
-#### <a name="publisher_items_anyOf_i1"></a>Property `Document > publisher > Organization object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of publisher
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| **Additional properties** | Any type allowed                                                                |
+| **Same definition as**    | [Organization](#conformsTo_items_identifier_anyOf_i1_anyOf_i1_creator_anyOf_i1) |
 
 ## <a name="title"></a>Property `Document > title`
 
@@ -531,41 +405,18 @@ List of categories/genres for the Document
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be     | Description |
-| ----------------------------------- | ----------- |
-| [Category or link](#category_items) | -           |
+| Each item of this array must be | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [Concept](#category_items)      | A labeled value from an optionally specified concept scheme |
 
-### <a name="category_items"></a>Document > category > Category or link
-
-**Title:** Category or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Concept](#category_items_anyOf_i0) |
-| [Link](#category_items_anyOf_i1)    |
-
-#### <a name="category_items_anyOf_i0"></a>Property `Document > category > Category or link > anyOf > Concept`
+### <a name="category_items"></a>Document > category > Concept
 
 **Title:** Concept
 
-inline description of Concept
+A labeled value from an optionally specified concept scheme
 
-| **Type**                  | More than one type                                            |
-| ------------------------- | ------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                              |
-| **Same definition as**    | [Concept](#conformsTo_items_anyOf_i0_category_items_anyOf_i0) |
-
-#### <a name="category_items_anyOf_i1"></a>Property `Document > category > Category or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                          |
+| ------------------------- | ------------------------------------------- |
+| **Additional properties** | Any type allowed                            |
+| **Same definition as**    | [Concept](#conformsTo_items_category_items) |
 

--- a/jsonschema/docs/Identifier.md
+++ b/jsonschema/docs/Identifier.md
@@ -73,7 +73,6 @@ the agency that manages the identifier scheme
 | ------------------------------------------------------------ |
 | [Null allowed when not required](#anyOf_i1_creator_anyOf_i0) |
 | [Organization](#anyOf_i1_creator_anyOf_i1)                   |
-| [Link](#anyOf_i1_creator_anyOf_i2)                           |
 
 #### <a name="anyOf_i1_creator_anyOf_i0"></a>Property `Identifier > anyOf > Identifier as a complex object > creator > anyOf > Null allowed when not required`
 
@@ -92,16 +91,6 @@ inline description of the creator
 | ------------------------- | --------------------------------- |
 | **Additional properties** | Any type allowed                  |
 | **Defined in**            | [Organization](./Organization.md) |
-
-#### <a name="anyOf_i1_creator_anyOf_i2"></a>Property `Identifier > anyOf > Identifier as a complex object > creator > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the creator
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ### <a name="anyOf_i1_issued"></a>Property `Identifier > anyOf > Identifier as a complex object > issued`
 

--- a/jsonschema/docs/Kind.md
+++ b/jsonschema/docs/Kind.md
@@ -42,43 +42,20 @@ The address of the contact
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be          | Description |
-| ---------------------------------------- | ----------- |
-| [Address object or link](#address_items) | -           |
+| Each item of this array must be | Description               |
+| ------------------------------- | ------------------------- |
+| [Address](#address_items)       | A single physical address |
 
-### <a name="address_items"></a>Kind > address > Address object or link
-
-**Title:** Address object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                     |
-| ---------------------------------- |
-| [Address](#address_items_anyOf_i0) |
-| [Link](#address_items_anyOf_i1)    |
-
-#### <a name="address_items_anyOf_i0"></a>Property `Kind > address > Address object or link > anyOf > Address`
+### <a name="address_items"></a>Kind > address > Address
 
 **Title:** Address
 
-inline address information
+A single physical address
 
 | **Type**                  | `object`                |
 | ------------------------- | ----------------------- |
 | **Additional properties** | Any type allowed        |
 | **Defined in**            | [Address](./Address.md) |
-
-#### <a name="address_items_anyOf_i1"></a>Property `Kind > address > Address object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Address
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="hasEmail"></a>Property `Kind > hasEmail`
 

--- a/jsonschema/docs/Location.md
+++ b/jsonschema/docs/Location.md
@@ -168,7 +168,6 @@ The unique geographic identifier for the Location, e.g., the URI or other unique
 | ---------------------------------- |
 | [item 0](#identifier_anyOf_i0)     |
 | [Identifier](#identifier_anyOf_i1) |
-| [item 2](#identifier_anyOf_i2)     |
 
 ### <a name="identifier_anyOf_i0"></a>Property `Location > identifier > anyOf > item 0`
 
@@ -186,14 +185,6 @@ inline description of Identifier
 | **Additional properties** | Any type allowed              |
 | **Defined in**            | [Identifier](./Identifier.md) |
 
-### <a name="identifier_anyOf_i2"></a>Property `Location > identifier > anyOf > item 2`
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
 ## <a name="otherIdentifier"></a>Property `Location > otherIdentifier`
 
 **Title:** other identifier
@@ -203,39 +194,20 @@ A list of geographic identifiers for the Location besides the main identifier, e
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                 | Description |
-| ----------------------------------------------- | ----------- |
-| [otherIdentifier items](#otherIdentifier_items) | -           |
+| Each item of this array must be      | Description                                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------- |
+| [Identifier](#otherIdentifier_items) | A unique identifier and optionally it's scheme and other relevant information |
 
-### <a name="otherIdentifier_items"></a>Location > otherIdentifier > otherIdentifier items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                |
-| --------------------------------------------- |
-| [Identifier](#otherIdentifier_items_anyOf_i0) |
-| [item 1](#otherIdentifier_items_anyOf_i1)     |
-
-#### <a name="otherIdentifier_items_anyOf_i0"></a>Property `Location > otherIdentifier > otherIdentifier items > anyOf > Identifier`
+### <a name="otherIdentifier_items"></a>Location > otherIdentifier > Identifier
 
 **Title:** Identifier
 
-inline description of Identifier
+A unique identifier and optionally it's scheme and other relevant information
 
 | **Type**                  | More than one type                 |
 | ------------------------- | ---------------------------------- |
 | **Additional properties** | Any type allowed                   |
 | **Same definition as**    | [Identifier](#identifier_anyOf_i1) |
-
-#### <a name="otherIdentifier_items_anyOf_i1"></a>Property `Location > otherIdentifier > otherIdentifier items > anyOf > item 1`
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="geometry"></a>Property `Location > geometry`
 
@@ -291,7 +263,6 @@ The gazetteer to which the location belongs
 | ----------------------------------- |
 | [item 0](#inScheme_anyOf_i0)        |
 | [ConceptScheme](#inScheme_anyOf_i1) |
-| [item 2](#inScheme_anyOf_i2)        |
 
 ### <a name="inScheme_anyOf_i0"></a>Property `Location > inScheme > anyOf > item 0`
 
@@ -308,14 +279,6 @@ inline description of the gazetteer
 | ------------------------- | ----------------------------------- |
 | **Additional properties** | Any type allowed                    |
 | **Defined in**            | [Conceptscheme](./Conceptscheme.md) |
-
-### <a name="inScheme_anyOf_i2"></a>Property `Location > inScheme > anyOf > item 2`
-
-reference iri of the gazetteer
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="altLabel"></a>Property `Location > altLabel`
 

--- a/jsonschema/docs/Organization.md
+++ b/jsonschema/docs/Organization.md
@@ -51,43 +51,20 @@ Represents hierarchical containment of Organizations or OrganizationalUnits; ind
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                         | Description |
-| ------------------------------------------------------- | ----------- |
-| [Organization object or link](#subOrganizationOf_items) | -           |
+| Each item of this array must be          | Description                                                                         |
+| ---------------------------------------- | ----------------------------------------------------------------------------------- |
+| [Organization](#subOrganizationOf_items) | Information about an organization, including other organizations that it is part of |
 
-### <a name="subOrganizationOf_items"></a>Organization > subOrganizationOf > Organization object or link
-
-**Title:** Organization object or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                    |
-| ------------------------------------------------- |
-| [Organization](#subOrganizationOf_items_anyOf_i0) |
-| [Link](#subOrganizationOf_items_anyOf_i1)         |
-
-#### <a name="subOrganizationOf_items_anyOf_i0"></a>Property `Organization > subOrganizationOf > Organization object or link > anyOf > Organization`
+### <a name="subOrganizationOf_items"></a>Organization > subOrganizationOf > Organization
 
 **Title:** Organization
 
-inline description of Organization
+Information about an organization, including other organizations that it is part of
 
 | **Type**                  | `object`              |
 | ------------------------- | --------------------- |
 | **Additional properties** | Any type allowed      |
 | **Same definition as**    | [Organization](#root) |
-
-#### <a name="subOrganizationOf_items_anyOf_i1"></a>Property `Organization > subOrganizationOf > Organization object or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Organization
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="altLabel"></a>Property `Organization > altLabel`
 

--- a/jsonschema/docs/QualityMeasurement.md
+++ b/jsonschema/docs/QualityMeasurement.md
@@ -8,13 +8,13 @@ A single measurement of one metric
 | ------------------------- | ---------------- |
 | **Additional properties** | Any type allowed |
 
-| Property                               | Type               | Title/Description |
-| -------------------------------------- | ------------------ | ----------------- |
-| - [@id](#@id )                         | string             | -                 |
-| - [@type](#@type )                     | string             | -                 |
-| + [isMeasurementOf](#isMeasurementOf ) | More than one type | is measurement of |
-| + [value](#value )                     | string             | value             |
-| - [unitMeasure](#unitMeasure )         | null or string     | unit of measure   |
+| Property                               | Type           | Title/Description |
+| -------------------------------------- | -------------- | ----------------- |
+| - [@id](#@id )                         | string         | -                 |
+| - [@type](#@type )                     | string         | -                 |
+| + [isMeasurementOf](#isMeasurementOf ) | object         | is measurement of |
+| + [value](#value )                     | string         | value             |
+| - [unitMeasure](#unitMeasure )         | null or string | unit of measure   |
 
 ## <a name="@id"></a>Property `QualityMeasurement > @id`
 
@@ -34,36 +34,11 @@ A single measurement of one metric
 
 The metric being observed
 
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Required**              | Yes                |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Metric](#isMeasurementOf_anyOf_i0) |
-| [Link](#isMeasurementOf_anyOf_i1)   |
-
-### <a name="isMeasurementOf_anyOf_i0"></a>Property `QualityMeasurement > isMeasurementOf > anyOf > Metric`
-
-**Title:** Metric
-
-inline description of Metric
-
 | **Type**                  | `object`              |
 | ------------------------- | --------------------- |
+| **Required**              | Yes                   |
 | **Additional properties** | Any type allowed      |
 | **Defined in**            | [Metric](./Metric.md) |
-
-### <a name="isMeasurementOf_anyOf_i1"></a>Property `QualityMeasurement > isMeasurementOf > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Metric
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="value"></a>Property `QualityMeasurement > value`
 

--- a/jsonschema/docs/Standard.md
+++ b/jsonschema/docs/Standard.md
@@ -137,7 +137,6 @@ The unique identifier for the Standard, e.g. the URI or other unique identifier 
 | ------------------------------------------------------ |
 | [Null allowed when not required](#identifier_anyOf_i0) |
 | [Identifier](#identifier_anyOf_i1)                     |
-| [Link](#identifier_anyOf_i2)                           |
 
 ### <a name="identifier_anyOf_i0"></a>Property `Standard > identifier > anyOf > Null allowed when not required`
 
@@ -157,16 +156,6 @@ inline description of Identifier
 | **Additional properties** | Any type allowed              |
 | **Defined in**            | [Identifier](./Identifier.md) |
 
-### <a name="identifier_anyOf_i2"></a>Property `Standard > identifier > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
-
 ## <a name="otherIdentifier"></a>Property `Standard > otherIdentifier`
 
 **Title:** other identifier
@@ -176,41 +165,20 @@ A list of identifiers for the Standard besides the main identifier, e.g. the URI
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be                 | Description |
-| ----------------------------------------------- | ----------- |
-| [otherIdentifier items](#otherIdentifier_items) | -           |
+| Each item of this array must be      | Description                                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------- |
+| [Identifier](#otherIdentifier_items) | A unique identifier and optionally it's scheme and other relevant information |
 
-### <a name="otherIdentifier_items"></a>Standard > otherIdentifier > otherIdentifier items
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                                |
-| --------------------------------------------- |
-| [Identifier](#otherIdentifier_items_anyOf_i0) |
-| [Link](#otherIdentifier_items_anyOf_i1)       |
-
-#### <a name="otherIdentifier_items_anyOf_i0"></a>Property `Standard > otherIdentifier > otherIdentifier items > anyOf > Identifier`
+### <a name="otherIdentifier_items"></a>Standard > otherIdentifier > Identifier
 
 **Title:** Identifier
 
-inline description of Identifier
+A unique identifier and optionally it's scheme and other relevant information
 
 | **Type**                  | More than one type                 |
 | ------------------------- | ---------------------------------- |
 | **Additional properties** | Any type allowed                   |
 | **Same definition as**    | [Identifier](#identifier_anyOf_i1) |
-
-#### <a name="otherIdentifier_items_anyOf_i1"></a>Property `Standard > otherIdentifier > otherIdentifier items > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Identifier
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="issued"></a>Property `Standard > issued`
 
@@ -379,43 +347,20 @@ List of categories for the Standard
 | **Type** | `null or array` |
 | -------- | --------------- |
 
-| Each item of this array must be     | Description |
-| ----------------------------------- | ----------- |
-| [Category or link](#category_items) | -           |
+| Each item of this array must be | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [Concept](#category_items)      | A labeled value from an optionally specified concept scheme |
 
-### <a name="category_items"></a>Standard > category > Category or link
-
-**Title:** Category or link
-
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                      |
-| ----------------------------------- |
-| [Concept](#category_items_anyOf_i0) |
-| [Link](#category_items_anyOf_i1)    |
-
-#### <a name="category_items_anyOf_i0"></a>Property `Standard > category > Category or link > anyOf > Concept`
+### <a name="category_items"></a>Standard > category > Concept
 
 **Title:** Concept
 
-inline description of Concept
+A labeled value from an optionally specified concept scheme
 
 | **Type**                  | More than one type      |
 | ------------------------- | ----------------------- |
 | **Additional properties** | Any type allowed        |
 | **Defined in**            | [Concept](./Concept.md) |
-
-#### <a name="category_items_anyOf_i1"></a>Property `Standard > category > Category or link > anyOf > Link`
-
-**Title:** Link
-
-reference iri of Concept
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="inScheme"></a>Property `Standard > inScheme`
 
@@ -431,7 +376,6 @@ The reference register to which the Standard belongs
 | ---------------------------------------------------- |
 | [Null allowed when not required](#inScheme_anyOf_i0) |
 | [ConceptScheme](#inScheme_anyOf_i1)                  |
-| [Link](#inScheme_anyOf_i2)                           |
 
 ### <a name="inScheme_anyOf_i0"></a>Property `Standard > inScheme > anyOf > Null allowed when not required`
 
@@ -446,18 +390,8 @@ The reference register to which the Standard belongs
 
 inline description of ConceptScheme
 
-| **Type**                  | `object`                                                             |
-| ------------------------- | -------------------------------------------------------------------- |
-| **Additional properties** | Any type allowed                                                     |
-| **Same definition as**    | [ConceptScheme](#category_items_anyOf_i0_anyOf_i1_inScheme_anyOf_i0) |
-
-### <a name="inScheme_anyOf_i2"></a>Property `Standard > inScheme > anyOf > Link`
-
-**Title:** Link
-
-reference iri of ConceptScheme
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | `object`                                      |
+| ------------------------- | --------------------------------------------- |
+| **Additional properties** | Any type allowed                              |
+| **Same definition as**    | [inScheme](#category_items_anyOf_i1_inScheme) |
 

--- a/jsonschema/docs/UseRestriction.md
+++ b/jsonschema/docs/UseRestriction.md
@@ -13,7 +13,7 @@ A restriction on usage of another item
 | - [@id](#@id )                                 | string             | -                    |
 | - [@type](#@type )                             | string             | -                    |
 | - [restrictionNote](#restrictionNote )         | null or string     | restriction note     |
-| + [restrictionStatus](#restrictionStatus )     | More than one type | restriction status   |
+| + [restrictionStatus](#restrictionStatus )     | object             | restriction status   |
 | - [specificRestriction](#specificRestriction ) | More than one type | specific restriction |
 
 ## <a name="@id"></a>Property `UseRestriction > @id`

--- a/jsonschema/docs/UseRestriction.md
+++ b/jsonschema/docs/UseRestriction.md
@@ -14,7 +14,7 @@ A restriction on usage of another item
 | - [@type](#@type )                             | string             | -                                                                                         |
 | - [restrictionNote](#restrictionNote )         | null or string     | restriction note                                                                          |
 | - [restrictionNoteMap](#restrictionNoteMap )   | null or object     | Language map for the restriction note. E.g. {'es': 'spanish words', 'fr': 'french words'} |
-| + [restrictionStatus](#restrictionStatus )     | More than one type | restriction status                                                                        |
+| + [restrictionStatus](#restrictionStatus )     | object             | restriction status                                                                        |
 | - [specificRestriction](#specificRestriction ) | More than one type | specific restriction                                                                      |
 
 ## <a name="@id"></a>Property `UseRestriction > @id`
@@ -51,36 +51,11 @@ Language map for the restriction note. E.g. {'es': 'spanish words', 'fr': 'frenc
 
 Indication of whether or not there are use restrictions on the archival materials
 
-| **Type**                  | More than one type |
-| ------------------------- | ------------------ |
-| **Required**              | Yes                |
-| **Additional properties** | Any type allowed   |
-
-| Any of(Option)                         |
-| -------------------------------------- |
-| [Concept](#restrictionStatus_anyOf_i0) |
-| [Link](#restrictionStatus_anyOf_i1)    |
-
-### <a name="restrictionStatus_anyOf_i0"></a>Property `UseRestriction > restrictionStatus > anyOf > Concept`
-
-**Title:** Concept
-
-inline description of restriction status
-
 | **Type**                  | More than one type      |
 | ------------------------- | ----------------------- |
+| **Required**              | Yes                     |
 | **Additional properties** | Any type allowed        |
 | **Defined in**            | [Concept](./Concept.md) |
-
-### <a name="restrictionStatus_anyOf_i1"></a>Property `UseRestriction > restrictionStatus > anyOf > Link`
-
-**Title:** Link
-
-reference iri of restriction status
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
 
 ## <a name="specificRestriction"></a>Property `UseRestriction > specificRestriction`
 
@@ -96,7 +71,6 @@ The specific NARA restriction associated with the use restriction
 | --------------------------------------------------------------- |
 | [Null allowed when not required](#specificRestriction_anyOf_i0) |
 | [Concept](#specificRestriction_anyOf_i1)                        |
-| [Link](#specificRestriction_anyOf_i2)                           |
 
 ### <a name="specificRestriction_anyOf_i0"></a>Property `UseRestriction > specificRestriction > anyOf > Null allowed when not required`
 
@@ -111,18 +85,8 @@ The specific NARA restriction associated with the use restriction
 
 inline description of the specific restriction
 
-| **Type**                  | More than one type                     |
-| ------------------------- | -------------------------------------- |
-| **Additional properties** | Any type allowed                       |
-| **Same definition as**    | [Concept](#restrictionStatus_anyOf_i0) |
-
-### <a name="specificRestriction_anyOf_i2"></a>Property `UseRestriction > specificRestriction > anyOf > Link`
-
-**Title:** Link
-
-reference iri of the specific restriction
-
-| **Type**   | `string` |
-| ---------- | -------- |
-| **Format** | `iri`    |
+| **Type**                  | More than one type                      |
+| ------------------------- | --------------------------------------- |
+| **Additional properties** | Any type allowed                        |
+| **Same definition as**    | [restrictionStatus](#restrictionStatus) |
 

--- a/jsonschema/examples/Agent/good/complete_example.json
+++ b/jsonschema/examples/Agent/good/complete_example.json
@@ -10,7 +10,7 @@
       "altLabel": "Federal Agency",
       "definition": "A government organization responsible for public administration and policy implementation.",
       "notation": ["GOV-AGY", "FA"],
-      "inScheme": "https://example.gov/concept-schemes/organization-types"
+      "inScheme": { "title": "Minimal concept scheme" }
     }
   ]
 }

--- a/jsonschema/examples/Concept/good/object_with_iri_inScheme.json
+++ b/jsonschema/examples/Concept/good/object_with_iri_inScheme.json
@@ -1,8 +1,0 @@
-{
-  "@id": "https://example.gov/concepts/transportation",
-  "@type": "Concept",
-  "prefLabel": "Transportation",
-  "definition": "Data related to the movement of people and goods via various modes of transport.",
-  "notation": [ "TRANS", "T01" ],
-  "inScheme": "https://example.gov/concept-schemes/data-themes"
-}

--- a/jsonschema/examples/Dataset/good/comprehensive-dataset.json
+++ b/jsonschema/examples/Dataset/good/comprehensive-dataset.json
@@ -18,7 +18,7 @@
     "name": "Sample Government Agency",
     "altLabel": "SGA",
     "prefLabel": "Sample Government Agency",
-    "notation": [ "SGA", "SAMPLE-GOV" ],
+    "notation": ["SGA", "SAMPLE-GOV"],
     "subOrganizationOf": [
       {
         "@id": "https://example.gov/organizations/parent-department",
@@ -51,7 +51,15 @@
       "description": "A sample CSV file for preview"
     }
   ],
-  "supportedSchema": "https://example.gov/schemas/data-schema-v1",
+  "supportedSchema": {
+    "description": "A minimal dataset",
+    "publisher": { "name": "The Minimal Organization" },
+    "title": "Dataset One",
+    "contactPoint": {
+      "hasEmail": "mailto:example@example.gov",
+      "fn": "Example contact"
+    }
+  },
   "versionNotes": "Initial release of the comprehensive example dataset with all fields populated.",
   "contactPoint": [
     {
@@ -87,7 +95,7 @@
       "format": "CSV (Comma-Separated Values)",
       "description": "Main CSV distribution of the dataset",
       "title": "Comprehensive Dataset CSV",
-      "characterEncoding": [ "UTF-8" ],
+      "characterEncoding": ["UTF-8"],
       "spatialResolutionInMeters": "100",
       "temporalResolution": "P1D",
       "issued": null,
@@ -103,10 +111,34 @@
       "description": "JSON distribution of the dataset"
     }
   ],
-  "first": "https://example.gov/datasets/comprehensive-example-first",
-  "hasCurrentVersion": "https://example.gov/datasets/comprehensive-example-001",
+  "first": {
+    "description": "A minimal dataset",
+    "publisher": { "name": "The Minimal Organization" },
+    "title": "Dataset One",
+    "contactPoint": {
+      "hasEmail": "mailto:example@example.gov",
+      "fn": "Example contact"
+    }
+  },
+  "hasCurrentVersion": {
+    "description": "A minimal dataset",
+    "publisher": { "name": "The Minimal Organization" },
+    "title": "Dataset One",
+    "contactPoint": {
+      "hasEmail": "mailto:example@example.gov",
+      "fn": "Example contact"
+    }
+  },
   "hasVersion": [
-    "https://example.gov/datasets/comprehensive-example-v0.9"
+    {
+      "description": "A minimal dataset",
+      "publisher": { "name": "The Minimal Organization" },
+      "title": "Dataset One",
+      "contactPoint": {
+        "hasEmail": "mailto:example@example.gov",
+        "fn": "Example contact"
+      }
+    }
   ],
   "inSeries": [
     {
@@ -122,24 +154,54 @@
           "hasEmail": "mailto:series@example.gov"
         }
       ],
-      "first": "https://example.gov/datasets/comprehensive-example-first",
-      "last": "https://example.gov/datasets/comprehensive-example-001"
+      "first": {
+        "description": "A minimal dataset",
+        "publisher": { "name": "The Minimal Organization" },
+        "title": "Dataset One",
+        "contactPoint": {
+          "hasEmail": "mailto:example@example.gov",
+          "fn": "Example contact"
+        }
+      },
+      "last": {
+        "description": "A minimal dataset",
+        "publisher": { "name": "The Minimal Organization" },
+        "title": "Dataset One",
+        "contactPoint": {
+          "hasEmail": "mailto:example@example.gov",
+          "fn": "Example contact"
+        }
+      }
     }
   ],
-  "keyword": [ "government", "open data", "comprehensive example", "DCAT-US", "metadata" ],
+  "keyword": [
+    "government",
+    "open data",
+    "comprehensive example",
+    "DCAT-US",
+    "metadata"
+  ],
   "keywordMap": {
-    "es": [ "gobierno", "datos abiertos", "ejemplo completo" ],
-    "fr": [ "gouvernement", "données ouvertes", "exemple complet" ]
+    "es": ["gobierno", "datos abiertos", "ejemplo completo"],
+    "fr": ["gouvernement", "données ouvertes", "exemple complet"]
   },
   "landingPage": {
     "@id": "https://example.gov/datasets/comprehensive-example-001/landing",
     "@type": "Document",
     "title": "Comprehensive Dataset Landing Page",
     "abstract": "The official landing page for the Comprehensive DCAT-US Dataset Example",
-    "creators": [ "Sample Government Agency" ],
+    "creators": ["Sample Government Agency"],
     "publishers": "Sample Government Agency"
   },
-  "previousVersion": "https://example.gov/datasets/comprehensive-example-v0.9",
+  "previousVersion": {
+    "description": "A minimal dataset",
+    "publisher": { "name": "The Minimal Organization" },
+    "title": "Dataset One",
+    "contactPoint": {
+      "hasEmail": "mailto:example@example.gov",
+      "fn": "Example contact"
+    }
+  },
   "qualifiedRelation": [
     {
       "@id": "https://example.gov/relationships/related-dataset-rel",
@@ -213,15 +275,22 @@
     "name": "Original Dataset Creator"
   },
   "hasPart": [
-    "https://example.gov/datasets/comprehensive-part-1",
-    "https://example.gov/datasets/comprehensive-part-2"
+    {
+      "description": "A minimal dataset",
+      "publisher": { "name": "The Minimal Organization" },
+      "title": "Dataset One",
+      "contactPoint": {
+        "hasEmail": "mailto:example@example.gov",
+        "fn": "Example contact"
+      }
+    }
   ],
   "isReferencedBy": [
     "https://example.gov/publications/annual-report-2024",
     "https://example.gov/publications/data-quality-study"
   ],
   "issued": null,
-  "language": [ "en", "es" ],
+  "language": ["en", "es"],
   "modified": null,
   "provenance": [
     "Data was collected through automated sensors deployed across the continental United States."
@@ -231,7 +300,15 @@
     "https://example.gov/services/api-endpoint"
   ],
   "replaces": [
-    "https://example.gov/datasets/legacy-comprehensive-dataset"
+    {
+      "description": "A minimal dataset",
+      "publisher": { "name": "The Minimal Organization" },
+      "title": "Dataset One",
+      "contactPoint": {
+        "hasEmail": "mailto:example@example.gov",
+        "fn": "Example contact"
+      }
+    }
   ],
   "rights": [
     "Copyright 2024 Sample Government Agency. Released under CC0 1.0 Universal."
@@ -245,7 +322,15 @@
     }
   ],
   "source": [
-    "https://example.gov/datasets/raw-sensor-data"
+    {
+      "description": "A minimal dataset",
+      "publisher": { "name": "The Minimal Organization" },
+      "title": "Dataset One",
+      "contactPoint": {
+        "hasEmail": "mailto:example@example.gov",
+        "fn": "Example contact"
+      }
+    }
   ],
   "temporal": [
     {
@@ -276,7 +361,7 @@
       "@type": "Document",
       "title": "User Guide",
       "abstract": "A comprehensive guide for using this dataset",
-      "creators": [ "Documentation Team" ],
+      "creators": ["Documentation Team"],
       "publishers": "Sample Government Agency",
       "bibliographicCitation": "Sample Government Agency. (2024). Comprehensive Dataset User Guide."
     }

--- a/jsonschema/examples/Dataset/good/good-accrual-periodicity.json
+++ b/jsonschema/examples/Dataset/good/good-accrual-periodicity.json
@@ -2,7 +2,7 @@
   "@type": "Dataset",
   "title": "Example Dataset",
   "description": "A minimal dataset example with a valid periodicity",
-  "publisher": "https://example.gov/org/sample-agency",
+  "publisher": { "name": "The Minimal Organization" },
   "accrualPeriodicity": "quarterly",
   "contactPoint": [
     {

--- a/jsonschema/examples/Location/good/identifier_iri_reference.json
+++ b/jsonschema/examples/Location/good/identifier_iri_reference.json
@@ -3,5 +3,5 @@
   "@type": "Location",
   "prefLabel": "New York City",
   "identifier": "https://www.geonames.org/5128581/",
-  "inScheme": "https://www.geonames.org/"
+  "inScheme": { "title": "Minimal concept scheme" }
 }

--- a/jsonschema/test_json_schema.py
+++ b/jsonschema/test_json_schema.py
@@ -54,24 +54,24 @@ def find_meaningful_errors(errors):
 def summarize_error(error, prefix=""):
     """Summarize a single error into a human-readable string."""
     path = format_path(error.path)
-    
+
     # Handle anyOf/oneOf errors by finding meaningful sub-errors
     if error.validator in ("anyOf", "oneOf") and error.context:
         meaningful = find_meaningful_errors(error.context)
-        
+
         # If all sub-errors are null-type, we have a different problem
         if not meaningful:
             return f"{prefix}{path}: field is not null and does not match any allowed type"
-        
+
         # Check if it's a simple "not null and wrong type" case
         has_null_alternative = any(is_null_type_error(e) for e in error.context)
-        
+
         summaries = []
         for sub_error in meaningful:
             sub_summary = summarize_error(sub_error, prefix="")
             if sub_summary:
                 summaries.append(sub_summary)
-        
+
         if has_null_alternative and summaries:
             intro = f"{path}: field is not null and "
             if len(summaries) == 1:
@@ -87,7 +87,7 @@ def summarize_error(error, prefix=""):
                 return f"{prefix}{path}: does not match any alternative:\n" + "\n".join(
                     f"{prefix}    - {s}" for s in summaries
                 )
-    
+
     # Handle $ref errors - find the expected class
     if "$ref" in error.schema:
         class_name = extract_schema_name(error.schema)
@@ -103,7 +103,7 @@ def summarize_error(error, prefix=""):
                     return "; ".join(sub_summaries)
         if class_name:
             return f"does not conform to {class_name}"
-    
+
     # Handle required field errors
     if error.validator == "required":
         missing = error.validator_value
@@ -116,26 +116,26 @@ def summarize_error(error, prefix=""):
             field = error.message.split("'")[1]
             return f"missing required field '{field}'"
         return error.message
-    
+
     # Handle type errors
     if error.validator == "type":
         expected = error.validator_value
         if isinstance(expected, list):
             expected = " or ".join(expected)
-        return f"expected type '{expected}'"
-    
+        return f"{prefix}{path}: expected type '{expected}'"
+
     # Handle enum errors
     if error.validator == "enum":
         return f"value not in allowed values: {error.validator_value}"
-    
+
     # Handle pattern errors
     if error.validator == "pattern":
         return f"does not match pattern '{error.validator_value}'"
-    
+
     # Handle format errors
     if error.validator == "format":
         return f"invalid format, expected '{error.validator_value}'"
-    
+
     # Default: use the message
     return error.message
 
@@ -144,13 +144,13 @@ def format_validation_errors(errors, indent=0):
     """Format validation errors with summarization and clear nesting."""
     output = []
     prefix = "  " * indent
-    
+
     # Group errors by their root path for cleaner output
     for error in sorted(errors, key=lambda e: list(e.path)):
         summary = summarize_error(error, prefix=prefix)
         if summary:
             output.append(summary)
-    
+
     return "\n".join(output)
 
 def load_schema_registry(script_dir):


### PR DESCRIPTION
As discussed in #107 we are removing the ubiquitous link possibilities that were there for many of the properties. This change also simplifies the documentation a great deal. The examples had to be tweaked to match.

(Again, apologies to anyone who has to review all of this PR.)