### PR TITLE
BUG: remove extraneous IRI restrictions

### DIFF
--- a/jsonschema/definitions/Metric.json
+++ b/jsonschema/definitions/Metric.json
@@ -20,8 +20,7 @@
     "inDimension": {
       "title": "in dimension",
       "description": "Represents the dimensions a quality metric, certificate and annotation allow a measurement of.",
-      "type": "string",
-      "format": "iri"
+      "type": "string"
     },
     "definition": {
       "title": "definition",

--- a/jsonschema/definitions/Relationship.json
+++ b/jsonschema/definitions/Relationship.json
@@ -20,9 +20,8 @@
     },
     "relation": {
       "title": "relation",
-      "description": "Link to the entity related to the dataset",
-      "type": "string",
-      "format": "iri"
+      "description": "The entity related to the dataset. This string should unambiguously identify the related resource using an appropriate identifier.",
+      "type": "string"
     }
   },
   "required": ["hadRole", "relation"]

--- a/jsonschema/docs/Metric.md
+++ b/jsonschema/docs/Metric.md
@@ -45,7 +45,6 @@ Represents the dimensions a quality metric, certificate and annotation allow a m
 | **Type**     | `string` |
 | ------------ | -------- |
 | **Required** | Yes      |
-| **Format**   | `iri`    |
 
 ## <a name="definition"></a>Property `Metric > definition`
 

--- a/jsonschema/docs/Relationship.md
+++ b/jsonschema/docs/Relationship.md
@@ -41,10 +41,9 @@ The function of an entity or agent with respect to a dataset
 
 **Title:** relation
 
-Link to the entity related to the dataset
+The entity related to the dataset. This string should unambiguously identify the related resource using an appropriate identifier.
 
 | **Type**     | `string` |
 | ------------ | -------- |
 | **Required** | Yes      |
-| **Format**   | `iri`    |
 

--- a/jsonschema/examples/Metric/good/minimal_example.json
+++ b/jsonschema/examples/Metric/good/minimal_example.json
@@ -1,5 +1,5 @@
 {
   "@type": "Metric",
   "expectedDataType": "xsd:boolean",
-  "inDimension": "https://www.w3.org/TR/vocab-dqv/#dqv:completeness"
+  "inDimension": "height"
 }

--- a/jsonschema/examples/Relationship/good/minimal_example.json
+++ b/jsonschema/examples/Relationship/good/minimal_example.json
@@ -1,5 +1,5 @@
 {
   "@type": "Relationship",
   "hadRole": "contributor",
-  "relation": "https://example.gov/organizations/partner-agency"
+  "relation": "some resource"
 }


### PR DESCRIPTION
Resolves #128.

In a few places, we want to accept strings that refer to other things in the Universe, but we don't need to strictly require that people use IRIs to refer to these things. This removes those format requirements and provides some clarity on how to use one of the fields.