### PR TITLE
explore backporting documentation into schema

### DIFF
--- a/jsonschema/definitions/AccessRestriction.json
+++ b/jsonschema/definitions/AccessRestriction.json
@@ -3,6 +3,7 @@
   "$id": "https://resources.data.gov/dcat-us/3.0.0/definitions/accessrestriction",
   "title": "AccessRestriction",
   "description": "A restriction on the permitted access to a resource",
+  "$comment": "Access restrictions are employed to regulate and control access to sensitive or confidential content based on legal, ethical, security, or other relevant considerations, and may pertain to who can access the information, the purposes for which it can be accessed, and the conditions under which it can be utilized",
   "type": "object",
   "properties": {
     "@id": {
@@ -13,19 +14,17 @@
       "type": "string",
       "default": "AccessRestriction"
     },
-    "restrictionNote": {
-      "title": "restriction note",
-      "description": "A note related to the access restriction",
-      "type": ["null", "string"]
-    },
     "restrictionStatus": {
       "title": "restriction status",
-      "description": "The indication of whether or not there are access restrictions on the item",
-      "$ref": "/dcat-us/3.0.0/definitions/concept"
+      "description": "Indication of whether or not there are access restrictions on the data",
+      "$comment": "Adherence to NARA guidelines and standards should be a priority when defining access restrictions, ensuring responsible access to sensitive historical records; see https://www.archives.gov/research/catalog/lcdrg/authority-lists/access-restriction-status for a list of NARA Access Restriction Status Authorities",
+      "$ref": "/dcat-us/3.0.0/definitions/concept",
+      "_reqLevel": "mandatory"
     },
     "specificRestriction": {
       "title": "specific restriction",
-      "description": "The specific NARA restriction associated with this restriction",
+      "description": "Identifies the type/authority of the access restriction (e.g., the specific NARA restriction) on the data",
+      "$comment": "Adherence to NARA guidelines and standards should be a priority when defining access restrictions, ensuring responsible access to sensitive historical records; see https://www.archives.gov/research/catalog/lcdrg/authority-lists/specific-access-restriction for a list of NARA Specific Access Restriction Authorities",
       "anyOf": [
         {
           "type": "null",
@@ -35,8 +34,58 @@
           "$ref": "/dcat-us/3.0.0/definitions/concept",
           "description": "inline description of the specific restriction"
         }
-      ]
+      ],
+      "_reqLevel": "recommended"
+    },
+    "restrictionNote": {
+      "title": "restriction note",
+      "description": "A note related to the access restriction that may include additional context or annotations",
+      "$comment": "Its use depends on the 'restrictionStatus' property, and certain terms from the authority lists may require its application (e.g., it may clarify complex access restrictions, explain multiple levels of security classifications, identify restricting statutes, or explain access restrictions not covered by the authority lists)",
+      "type": ["null", "string"],
+      "_reqLevel": "optional"
     }
   },
-  "required": ["restrictionStatus"]
+  "required": ["restrictionStatus"],
+  "examples": [
+    {
+      "$comment": "A complete/thorough example of an instance of the AccessRestriction class",
+      "@id": "https://example.gov/restrictions/access-restriction-001",
+      "@type": "AccessRestriction",
+      "restrictionNote": "Access restricted to authorized personnel only.",
+      "restrictionStatus": {
+        "@id": "https://example.gov/concepts/restricted-partly",
+        "@type": "Concept",
+        "prefLabel": "Restricted - Partly",
+        "definition": "The resource contains microdata including highly sensitive Personally Identifiable Information (PII). Access is restricted to those with Special Sworn Status (SSS).",
+        "notation": ["RST-P"],
+        "inScheme": {
+          "@id": "https://example.gov/concept-schemes/restriction-status",
+          "@type": "ConceptScheme",
+          "title": "Restriction Status"
+        }
+      },
+      "specificRestriction": {
+        "@id": "https://example.gov/concepts/nara-restriction-pii",
+        "@type": "Concept",
+        "prefLabel": "Personal Information Restriction",
+        "definition": "An access restriction placed on archival materials with personal information that invades the privacy of living individuals.",
+        "notation": ["FOIA (b)(6) Personal Information"],
+        "inScheme": {
+          "@id": "https://example.gov/concept-schemes/nara-restrictions",
+          "@type": "ConceptScheme",
+          "title": "NARA Restrictions"
+        }
+      }
+    },
+    {
+      "$comment": "A typical example of an instance of the AccessRestriction class",
+      "@type": "AccessRestriction",
+      "restrictionStatus": "https://example.gov/concepts/restricted",
+      "restrictionNote": "Access restricted to authorized personnel only."
+    },
+    {
+      "$comment": "A minimal example of an instance of the AccessRestriction class",
+      "restrictionStatus": "Restricted"
+    }
+  ]
 }

--- a/jsonschema/definitions/AccessRestriction.json
+++ b/jsonschema/definitions/AccessRestriction.json
@@ -56,7 +56,7 @@
         "@id": "https://example.gov/concepts/restricted-partly",
         "@type": "Concept",
         "prefLabel": "Restricted - Partly",
-        "definition": "The resource contains microdata including highly sensitive Personally Identifiable Information (PII). Access is restricted to those with Special Sworn Status (SSS).",
+        "definition": "The resource is partially restricted and has additional conditions/requirements for access.",
         "notation": ["RST-P"],
         "inScheme": {
           "@id": "https://example.gov/concept-schemes/restriction-status",

--- a/jsonschema/definitions/CUIRestriction.json
+++ b/jsonschema/definitions/CUIRestriction.json
@@ -2,7 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://resources.data.gov/dcat-us/3.0.0/definitions/cuirestriction",
   "title": "CUIRestriction",
-  "description": "A specific restriction on handling Controlled Unclassified Information (CUI)",
+  "description": "A specific restriction on handling Controlled Unclassified Information (CUI) that describes the handling and dissemination controls for NARA assets that involve CUI, as mandated by law",
+  "$comment": "Controlled Unclassified Information (CUI) is information that requires safeguarding or dissemination controls pursuant to and consistent with applicable law, regulations, and government-wide policies but which is not classified; see https://www.archives.gov/cui for more info",
   "type": "object",
   "properties": {
     "@id": {
@@ -15,23 +16,46 @@
     },
     "cuiBannerMarking": {
       "title": "CUI banner marking",
-      "description": "CUI (Controlled Unclassified Information) banner marking is required for any unclassified information that is deemed sensitive and requires protection",
-      "type": "string"
+      "description": "Required for any unclassified information that is deemed sensitive and requires protection; see https://www.archives.gov/cui/registry/category-marking-list for a table of CUI categories and markings",
+      "type": "string",
+      "_reqLevel": "mandatory"
     },
     "designationIndicator": {
       "title": "CUI designation indicator",
-      "description": "Designation Indicator shows which agency made the document CUI",
-      "type": "string"
+      "description": "Shows which agency made the document CUI",
+      "$comment": "While free-text, metadata providers should attempt to adhere to guidelines in the NARA Marking Guidebook (https://www.archives.gov/files/cui/documents/20161206-cui-marking-handbook-v1-1-20190524.pdf) and DODI 5200.48 (https://www.dodcui.mil/Portals/109/Documents/Policy%20Docs/DoDI%205200.48%20CUI.pdf)",
+      "type": "string",
+      "_reqLevel": "mandatory"
     },
     "requiredIndicatorPerAuthority": {
       "title": "required indicator per authority",
-      "description": "List of free text of the required indicator",
+      "description": "List of free text that may offer additional information or context about the CUI restriction",
       "type": ["null", "array"],
       "items": {
         "title": "Indicator string",
         "type": "string"
-      }
+      },
+      "_reqLevel": "optional"
     }
   },
-  "required": ["cuiBannerMarking", "designationIndicator"]
+  "required": ["cuiBannerMarking", "designationIndicator"],
+  "examples": [
+    {
+      "$comment": "A complete/thorough example of an instance of the CUIRestriction class",
+      "@id": "https://example.gov/cui-restrictions/dataset-001",
+      "@type": "CUIRestriction",
+      "cuiBannerMarking": "CUI//SP-PRVCY//SP-LEGAL",
+      "designationIndicator": "DOC",
+      "requiredIndicatorPerAuthority": [
+        "Privacy Act of 1974",
+        "Federal Records Act"
+      ]
+    },
+    {
+      "$comment": "A typical example of an instance of the CUIRestriction class",
+      "@type": "CUIRestriction",
+      "cuiBannerMarking": "CUI//SP-CTI",
+      "designationIndicator": "Agency XYZ"
+    }
+  ]
 }

--- a/jsonschema/definitions/UseRestriction.json
+++ b/jsonschema/definitions/UseRestriction.json
@@ -2,7 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://resources.data.gov/dcat-us/3.0.0/definitions/userestriction",
   "title": "UseRestriction",
-  "description": "A restriction on usage of another item",
+  "description": "A restriction on the usage of a resource, specifying a set of rules, guidelines, or legal provisions that dictate how a particular resource, asset, information, or object can be utilized",
+  "$comment": "Use restrictions may encompass limitations on access, distribution, reproduction, modification, or sharing, and they are often put in place to protect privacy, intellectual property rights, security, or compliance with legal or ethical standards",
   "type": "object",
   "properties": {
     "@id": {
@@ -13,19 +14,17 @@
       "type": "string",
       "default": "UseRestriction"
     },
-    "restrictionNote": {
-      "title": "restriction note",
-      "description": "Significant information pertaining to the use or reproduction of the data",
-      "type": ["null", "string"]
-    },
     "restrictionStatus": {
       "title": "restriction status",
-      "description": "Indication of whether or not there are use restrictions on the archival materials",
-      "$ref": "/dcat-us/3.0.0/definitions/concept"
+      "description": "Indication of whether or not there are use restrictions on the data",
+      "$comment": "Adherence to NARA guidelines and standards should be a priority when defining use restrictions, ensuring that data resources align with archival and preservation practices; see https://www.archives.gov/research/catalog/lcdrg/authority-lists/use-restriction-status for a list of NARA Use Restriction Status Authorities",
+      "$ref": "/dcat-us/3.0.0/definitions/concept",
+      "_reqLevel": "mandatory"
     },
     "specificRestriction": {
       "title": "specific restriction",
-      "description": "The specific NARA restriction associated with the use restriction",
+      "description": "The identification of the type of use restriction (e.g., the specific NARA restriction) on the data, based on copyright, donor, or statutory provisions",
+      "$comment": "Adherence to NARA guidelines and standards should be a priority when defining use restrictions, ensuring that data resources align with archival and preservation practices; see https://www.archives.gov/research/catalog/lcdrg/authority-lists/specific-use-restriction for a list of NARA Specific Use Restriction Authorities",
       "anyOf": [
         {
           "type": "null",
@@ -35,8 +34,59 @@
           "$ref": "/dcat-us/3.0.0/definitions/concept",
           "description": "inline description of the specific restriction"
         }
-      ]
+      ],
+      "_reqLevel": "recommended"
+    },
+    "restrictionNote": {
+      "title": "restriction note",
+      "description": "Significant information pertaining to the use or reproduction of the data",
+      "$comment": "May include additional context or annotations about restrictions; its use depends on the 'restrictionStatus' property, and certain terms from the authority lists may require its application",
+      "type": ["null", "string"],
+      "_reqLevel": "optional"
     }
   },
-  "required": ["restrictionStatus"]
+  "required": ["restrictionStatus"],
+  "examples": [
+    {
+      "$comment": "A complete/thorough example of an instance of the UseRestriction class",
+      "@id": "https://example.gov/restrictions/use-restriction-001",
+      "@type": "UseRestriction",
+      "restrictionNote": "This data may be used for research purposes. Commercial use requires written permission from the data steward.",
+      "restrictionStatus": {
+        "@id": "https://example.gov/concepts/restricted-commercial",
+        "@type": "Concept",
+        "prefLabel": "Restricted - Commercial Use",
+        "altLabel": "Commercial Restriction",
+        "definition": "The resource has restrictions on commercial use but is available for research and non-commercial purposes.",
+        "notation": ["RST-COM"],
+        "inScheme": {
+          "@id": "https://example.gov/concept-schemes/restriction-status",
+          "@type": "ConceptScheme",
+          "title": "Restriction Status"
+        }
+      },
+      "specificRestriction": {
+        "@id": "https://example.gov/concepts/nara-restriction-copyright",
+        "@type": "Concept",
+        "prefLabel": "Copyright Restriction",
+        "definition": "Materials protected by copyright with limited use permissions.",
+        "notation": ["CR"],
+        "inScheme": {
+          "@id": "https://example.gov/concept-schemes/nara-restrictions",
+          "@type": "ConceptScheme",
+          "title": "NARA Restrictions"
+        }
+      }
+    },
+    {
+      "$comment": "A typical example of an instance of the UseRestriction class",
+      "@type": "UseRestriction",
+      "restrictionStatus": "https://example.gov/concepts/unrestricted",
+      "restrictionNote": "This data may be used for any purpose without restriction."
+    },
+    {
+      "$comment": "A minimal example of an instance of the UseRestriction class",
+      "restrictionStatus": "Unrestricted"
+    }
+  ]
 }

--- a/jsonschema/examples/AccessRestriction/good/complete_example.json
+++ b/jsonschema/examples/AccessRestriction/good/complete_example.json
@@ -6,7 +6,7 @@
     "@id": "https://example.gov/concepts/restricted-partly",
     "@type": "Concept",
     "prefLabel": "Restricted - Partly",
-    "definition": "The resource contains microdata including highly sensitive Personally Identifiable Information (PII). Access is restricted to those with Special Sworn Status (SSS).",
+    "definition": "The resource is partially restricted and has additional conditions/requirements for access.",
     "notation": ["RST-P"],
     "inScheme": {
       "@id": "https://example.gov/concept-schemes/restriction-status",

--- a/jsonschema/examples/AccessRestriction/good/complete_example.json
+++ b/jsonschema/examples/AccessRestriction/good/complete_example.json
@@ -1,0 +1,29 @@
+{
+  "@id": "https://example.gov/restrictions/access-restriction-001",
+  "@type": "AccessRestriction",
+  "restrictionNote": "Access restricted to authorized personnel only.",
+  "restrictionStatus": {
+    "@id": "https://example.gov/concepts/restricted-partly",
+    "@type": "Concept",
+    "prefLabel": "Restricted - Partly",
+    "definition": "The resource contains microdata including highly sensitive Personally Identifiable Information (PII). Access is restricted to those with Special Sworn Status (SSS).",
+    "notation": ["RST-P"],
+    "inScheme": {
+      "@id": "https://example.gov/concept-schemes/restriction-status",
+      "@type": "ConceptScheme",
+      "title": "Restriction Status"
+    }
+  },
+  "specificRestriction": {
+    "@id": "https://example.gov/concepts/nara-restriction-pii",
+    "@type": "Concept",
+    "prefLabel": "Personal Information Restriction",
+    "definition": "An access restriction placed on archival materials with personal information that invades the privacy of living individuals.",
+    "notation": ["FOIA (b)(6) Personal Information"],
+    "inScheme": {
+      "@id": "https://example.gov/concept-schemes/nara-restrictions",
+      "@type": "ConceptScheme",
+      "title": "NARA Restrictions"
+    }
+  }
+}


### PR DESCRIPTION
**Related to:** #130 

**Relevant Documentation:** [AccessRestriction](https://doi-do.github.io/dcat-us/#properties-for-access_restriction), [CUIRestriction](https://doi-do.github.io/dcat-us/#properties-for-cui_restriction), [UseRestriction](https://doi-do.github.io/dcat-us/#properties-for-use_restriction), [NARA Legal Metadata](https://doi-do.github.io/dcat-us/#nara-access-restrictions)

**Affected classes:** `AccessRestriction`, `CUIRestriction`, `UseRestriction`

**Summary:** I wanted to test out/explore what backporting the DOI-DO/infopolicy documentation into the schema might look like before committing to extending the effort across all of the other classes. The `generate_schema_docs.py` script would also need to be updated to take into account the new `$comment`, `_reqLevel`, and `examples` fields and display them appropriately.

**Changes:**
- add info from documentation into `description` fields and/or add `$comment` fields where appropriate
- add `_reqLevel` field to each property in the classes; it indicates each property's requirement level (i.e, "mandatory", "recommended", "optional")
- sort the properties by `_reqLevel`
- add `examples` list that includes the complete, typical, and minimal examples for each class
- create `complete_example.json` for `AccessRestriction`