### PR TITLE
Add explicit workflow token permissions

### DIFF
--- a/.github/workflows/check-docs-up-to-date.yml
+++ b/.github/workflows/check-docs-up-to-date.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'jsonschema/**'
 
+permissions:
+  contents: read
+
 jobs:
   check-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-jsonschema.yml
+++ b/.github/workflows/validate-jsonschema.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'jsonschema/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -36,4 +39,3 @@ jobs:
       - name: Check JSON format with prettier
         working-directory: ./jsonschema
         run: npx prettier --check definitions/*.json examples/
-


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to JSON Schema validation workflows.
- Set `contents: read` in:
  - `.github/workflows/check-docs-up-to-date.yml`
  - `.github/workflows/validate-jsonschema.yml`

## Why
Code scanning recommends explicit least-privilege token permissions. This keeps workflow access scoped and predictable.