### PR TITLE
6061: Decouple v1.1 Validation from v3.0 Conversion

### DIFF
--- a/jsonschema/convert_dcat_1_1_to_3_0.py
+++ b/jsonschema/convert_dcat_1_1_to_3_0.py
@@ -3,6 +3,7 @@
 import copy
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import click
@@ -250,6 +251,18 @@ def convert_dcat_catalog(old_catalog: dict) -> dict:
     new_catalog.pop("@context", None)
     new_catalog.pop("describedBy", None)
 
+    # The catalog itself may have a `modified` timestamp so we normalize it to a
+    # timezone-aware date-time string, since v3.0 requires one.
+    catalog_modified = new_catalog.get("modified")
+    if isinstance(catalog_modified, str):
+        try:
+            parsed = datetime.fromisoformat(catalog_modified)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            new_catalog["modified"] = parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except ValueError:
+            del new_catalog["modified"]
+
     datasets = new_catalog.get("dataset", [])
     click.echo(f"Transforming {len(datasets)} datasets.")
     for i, dataset in enumerate(datasets):
@@ -298,9 +311,16 @@ def main(output_dir, url, dry_run):
     """Convert DCAT catalog."""
     v1_1_registry = load_schema_registry(V1_1_DEFINITIONS_DIR)
     v3_0_registry = load_schema_registry(V3_0_DEFINITIONS_DIR)
+    click.echo(f"Converting DCAT-US v1.1 to DCAT-US v3.0 for {url}")
     try:
         catalog_to_convert = fetch_dcat_catalog(url)
-        validate_catalog(V1_1_CATALOG_SCHEMA_ID, v1_1_registry, catalog_to_convert)
+
+        try:
+            validate_catalog(V1_1_CATALOG_SCHEMA_ID, v1_1_registry, catalog_to_convert)
+            click.echo("Input catalog is valid DCAT-US v1.1.")
+        except CatalogValidationException as e:
+            click.echo(f"Warning: input catalog failed v1.1 validation — converting anyway.")
+
         converted_catalog = convert_dcat_catalog(catalog_to_convert)
         validate_catalog(V3_0_CATALOG_SCHEMA_ID, v3_0_registry, converted_catalog)
         if dry_run:

--- a/jsonschema/tests/harvest_source_urls.csv
+++ b/jsonschema/tests/harvest_source_urls.csv
@@ -1,129 +1,129 @@
-url,status,has_valid_subset,notes
-https://www.eac.gov/data.json,converts,n/a
-https://data.ca.gov/data.json,invalid v1.1,yes
-https://open.gsa.gov/data.json,converts,n/a
-https://healthdata.gov/data.json,invalid v1.1,yes
-https://data.kingcounty.gov/data.json?version=2,invalid v1.1,yes
-https://data.hartford.gov/data.json,invalid v1.1,yes
-https://data-soa-dnr.opendata.arcgis.com/api/feed/dcat-us/1.1.json,invalid v1.1,no
-https://ddi.doi.gov/onrr-data.json,converts,n/a
-https://datainventory.doi.gov/data.json,fetch error,n/a
-https://www.imls.gov/sites/default/files/data.json,invalid v1.1,yes
-https://ddi.doi.gov/bia-data.json,converts,n/a
-https://ddi.doi.gov/bsee-data.json,invalid v1.1,yes
-https://portal.opentopography.org/geoportal/csw/discovery?Request=GetCapabilities&Service=CSW&Version=2.0.2,fetch error,n/a
-https://www.sba.gov/data.json,converts,n/a
-https://ddi.doi.gov/fws-data.json,converts,n/a
-https://ddi.doi.gov/osmre-data.json,invalid v1.1,no
-https://ddi.doi.gov/usgs-data.json,invalid v1.1,yes
-https://data.honolulu.gov/data.json?version=2,invalid v1.1,yes
-https://data-fairfaxcountygis.opendata.arcgis.com/data.json,invalid v1.1,yes
-https://ddi.doi.gov/doios-data.json,invalid v1.1,yes
-https://edg.epa.gov/data/nongeo_data.json,invalid v1.1,yes
-https://opendata.fcc.gov/data.json,invalid v1.1,yes
-https://nycopendata.socrata.com/data.json?version=2,invalid v1.1,yes
-https://www.ncua.gov/data.json,converts,n/a
-https://www.fec.gov/data.json,converts,n/a
-https://www.federalreserve.gov/PDC/data.json,converts,n/a
-https://opendata.hawaii.gov/data.json,invalid v1.1,yes
-https://img.exim.gov/s3fs-public/dataset/vbhv-d8am/data.json,converts,n/a
-https://ddi.doi.gov/blm-data.json,converts,n/a
-https://ddi.doi.gov/nps-data.json,converts,n/a
-https://data.brla.gov/data.json,invalid v1.1,yes
-https://www.commerce.gov/sites/default/files/data.json,fetch error,n/a
-https://data.ed.gov/data.json,invalid v1.1,yes
-https://data.iowa.gov/data.json,fetch error,n/a
-https://www.usda.gov/sites/default/files/documents/data.json,fetch error,n/a
-https://ddi.doi.gov/boem-data.json,converts,n/a
-https://ddi.doi.gov/usbr-data.json,converts,n/a
-https://datacatalog.cookcountyil.gov/data.json?version=2,invalid v1.1,yes
-https://data.nola.gov/data.json,invalid v1.1,yes
-https://data.sfgov.org/data.json?version=2,invalid v1.1,yes
-https://www.state.gov/data.json,converts,n/a
-https://data.ok.gov/data.json?version=2,invalid v1.1,yes
-https://data.ny.gov/data.json?version=2,invalid v1.1,yes
-https://www.cftc.gov/sites/default/files/CFTC-ODI-metadata-v2.json,converts,n/a
-https://data.cityofchicago.org/data.json?version=2,invalid v1.1,yes
-https://www.huduser.gov/data/data.json,converts,n/a
-https://fhfa.gov/data/data.json,converts,n/a
-https://its.ntia.gov/data.json,converts,n/a
-https://www.dol.gov/data.json,converts,n/a
-https://data.mo.gov/data.json?version=2,invalid v1.1,yes
-https://data.baltimorecity.gov/data.json,invalid v1.1,yes
-https://data.austintexas.gov/data.json,invalid v1.1,yes
-https://data.americorps.gov/data.json,converts,n/a
-https://www.consumerfinance.gov/data.json,converts,n/a
-https://data.somervillema.gov/data.json?version=2,invalid v1.1,yes
-https://cos-data.seattle.gov/data.json,invalid v1.1,yes
-https://data.townofcary.org/data.json,invalid v1.1,no
-https://www.archives.gov/files/data.json,converts,n/a
-https://www.usitc.gov/data.json,converts,n/a
-https://wa-node.gis.washington.edu/geoportal/csw/discovery,fetch error,n/a
-https://www.bls.gov/data.json,converts,n/a
-https://www.opm.gov/data.json,converts,n/a
-https://data.charlottenc.gov/data.json,invalid v1.1,no
-https://opendata-townofchapelhill.hub.arcgis.com/api/feed/dcat-us/1.1.json,invalid v1.1,yes
-https://data.mcc.gov/data.json,converts,n/a
-https://data.va.gov/data.json,invalid v1.1,yes
-https://www.frtib.gov/data.json,converts,n/a
-https://geohub-loudoungis.opendata.arcgis.com/data.json,invalid v1.1,yes
-https://data.ct.gov/data.json,invalid v1.1,yes
-https://data.wa.gov/data.json?version=2,invalid v1.1,yes
-https://data.oregon.gov/data.json?version=2,invalid v1.1,yes
-https://www.mspb.gov/data.json,converts,n/a
-https://data.providenceri.gov/data.json,invalid v1.1,yes
-https://public-chesva.opendata.arcgis.com/data.json,invalid v1.1,yes
-https://www.eeoc.gov/data.json,converts,n/a
-https://www.ssa.gov/data.json,invalid v1.1,yes
-https://www.ftc.gov/data.json,converts,n/a
-https://www.nsf.gov/data.json,converts,n/a
-https://cwbi-app.sec.usace.army.mil/pub/data.json,invalid v1.1,no
-https://www.nrc.gov/data.json,invalid v1.1,yes
-https://data.transportation.gov/data.json,invalid v1.1,yes
-https://geospatial-usace.opendata.arcgis.com/data.json,invalid v1.1,no
-https://opendata.maryland.gov/data.json,invalid v1.1,yes
-https://ngda-transportation-geoplatform.hub.arcgis.com/api/feed/dcat-us/1.1.json,invalid v1.1,yes
-https://gisportal.ibwc.gov/agsportal/,fetch error,n/a
-https://data.ferndalemi.gov/data.json,invalid v1.1,yes
-https://data.tempe.gov/api/feed/dcat-us/1.1.json,invalid v1.1,yes
-https://data.arlingtonva.us/data.json,invalid v1.1,no
-https://bloomington.data.socrata.com/data.json,invalid v1.1,yes
-https://data-wake.opendata.arcgis.com/data.json,invalid v1.1,yes
-https://data.ntsb.gov/data.json,converts,n/a
-https://secure.rrb.gov/data.json,converts,n/a
-https://www.dhs.gov/data.json,converts,n/a
-https://www.cpsc.gov/data.json,invalid v1.1,yes
-https://data.montgomerycountymd.gov/data.json,invalid v1.1,yes
-https://www.nitrd.gov/data.json,converts,n/a
-https://www.archive.arm.gov/metadata/data.json,converts,n/a
-https://data.usaid.gov/data.json,fetch error,n/a
-https://pbgc.gov/data.json,converts,n/a
-https://www.opendataphilly.org/data.json,invalid v1.1,yes
-https://www.nist.gov/sites/default/files/data.json,invalid v3.0,n/a,v1.1 is valid but uses reserved `replaces` field name
-https://www.treasury.gov/data.json,converts,n/a
-https://pasteur.epa.gov/metadata.json,converts,n/a
-https://max.gov/data.json,converts,n/a
-https://www.justice.gov/data.json,converts,n/a
-https://data.nasa.gov/data.json,fetch error,n/a
-https://federallabs.org/data.json,converts,n/a
-https://www.sec.gov/data.json,converts,n/a
-https://data.lacity.org/data.json,invalid v1.1,yes
-https://nehopendatastorage.blob.core.windows.net/nehopendata/data.json,converts,n/a
-https://openei.org/data.json,converts,n/a
-https://www.energy.gov/data.json,converts,n/a
-https://www.defense.gov/data.json,fetch error,n/a
-https://opendata.cityofboise.org/data.json,invalid v1.1,no
-https://opendata.dc.gov/data.json,invalid v1.1,yes
-https://data-lakecountyil.opendata.arcgis.com/data.json,invalid v1.1,yes
-https://geodata.vermont.gov/api/feed/dcat-us/1.1.json,invalid v1.1,yes
-https://dataworks.siouxfalls.gov/data.json,invalid v1.1,yes
-https://data.srcity.org/data.json,fetch error,n/a
-https://mapcontext.com/npswaf/sample2.json,fetch error,n/a
-https://data.wprdc.org/data.json,invalid v1.1,no
-https://apps.usgs.gov/fgdc/WAF_JSON/combined.json,converts,n/a
-https://geocatalog-uidaho.hub.arcgis.com/data.json,invalid v1.1,yes
-https://opendurham.nc.gov/data.json,fetch error,n/a
-https://rossi.urs-tally.com/Content/data.json,converts,n/a
-https://louisville-metro-opendata-lojic.hub.arcgis.com/api/feed/dcat-us/1.1.json,invalid v1.1,yes
-https://raw.githubusercontent.com/gbinal/data/master/datasets/hhs_cas.json,fetch error,n/a
-https://www.loc.gov/data.json,converts,n/a
+url,valid_v1.1,converts_to_v3.0,note
+https://www.eac.gov/data.json,yes,yes
+https://data.ca.gov/data.json,no,no
+https://open.gsa.gov/data.json,yes,yes
+https://healthdata.gov/data.json,no,no
+https://data.kingcounty.gov/data.json?version=2,no,yes
+https://data.hartford.gov/data.json,no,no
+https://data-soa-dnr.opendata.arcgis.com/api/feed/dcat-us/1.1.json,no,no
+https://ddi.doi.gov/onrr-data.json,yes,yes
+https://datainventory.doi.gov/data.json,unknown,fetch error
+https://www.imls.gov/sites/default/files/data.json,no,no
+https://ddi.doi.gov/bia-data.json,yes,yes
+https://ddi.doi.gov/bsee-data.json,no,yes
+https://portal.opentopography.org/geoportal/csw/discovery?Request=GetCapabilities&Service=CSW&Version=2.0.2,unknown,fetch error
+https://www.sba.gov/data.json,yes,yes
+https://ddi.doi.gov/fws-data.json,yes,yes
+https://ddi.doi.gov/osmre-data.json,no,yes
+https://ddi.doi.gov/usgs-data.json,no,no
+https://data.honolulu.gov/data.json?version=2,no,yes
+https://data-fairfaxcountygis.opendata.arcgis.com/data.json,no,yes
+https://ddi.doi.gov/doios-data.json,no,no
+https://edg.epa.gov/data/nongeo_data.json,no,yes
+https://opendata.fcc.gov/data.json,no,yes
+https://nycopendata.socrata.com/data.json?version=2,no,yes
+https://www.ncua.gov/data.json,yes,yes
+https://www.fec.gov/data.json,yes,yes
+https://www.federalreserve.gov/PDC/data.json,yes,yes
+https://opendata.hawaii.gov/data.json,no,no
+https://img.exim.gov/s3fs-public/dataset/vbhv-d8am/data.json,yes,yes
+https://ddi.doi.gov/blm-data.json,no,yes
+https://ddi.doi.gov/nps-data.json,no,yes
+https://data.brla.gov/data.json,no,yes
+https://www.commerce.gov/sites/default/files/data.json,unknown,fetch error
+https://data.ed.gov/data.json,no,no
+https://data.iowa.gov/data.json,unknown,fetch error
+https://www.usda.gov/sites/default/files/documents/data.json,unknown,fetch error
+https://ddi.doi.gov/boem-data.json,yes,yes
+https://ddi.doi.gov/usbr-data.json,yes,yes
+https://datacatalog.cookcountyil.gov/data.json?version=2,no,yes
+https://data.nola.gov/data.json,no,yes
+https://data.sfgov.org/data.json?version=2,no,yes
+https://www.state.gov/data.json,yes,yes
+https://data.ok.gov/data.json?version=2,no,no
+https://data.ny.gov/data.json?version=2,no,no
+https://www.cftc.gov/sites/default/files/CFTC-ODI-metadata-v2.json,yes,yes
+https://data.cityofchicago.org/data.json?version=2,no,yes
+https://www.huduser.gov/data/data.json,yes,yes
+https://fhfa.gov/data/data.json,yes,yes
+https://its.ntia.gov/data.json,yes,yes
+https://www.dol.gov/data.json,yes,yes
+https://data.mo.gov/data.json?version=2,no,yes
+https://data.baltimorecity.gov/data.json,no,no
+https://data.austintexas.gov/data.json,no,yes
+https://data.americorps.gov/data.json,yes,yes
+https://www.consumerfinance.gov/data.json,yes,yes
+https://data.somervillema.gov/data.json?version=2,no,yes
+https://cos-data.seattle.gov/data.json,no,no
+https://data.townofcary.org/data.json,no,no
+https://www.archives.gov/files/data.json,yes,yes
+https://www.usitc.gov/data.json,yes,yes
+https://wa-node.gis.washington.edu/geoportal/csw/discovery,unknown,fetch error
+https://www.bls.gov/data.json,yes,yes
+https://www.opm.gov/data.json,yes,yes
+https://data.charlottenc.gov/data.json,no,no
+https://opendata-townofchapelhill.hub.arcgis.com/api/feed/dcat-us/1.1.json,no,no
+https://data.mcc.gov/data.json,yes,yes
+https://data.va.gov/data.json,no,no
+https://www.frtib.gov/data.json,yes,yes
+https://geohub-loudoungis.opendata.arcgis.com/data.json,no,no
+https://data.ct.gov/data.json,no,no
+https://data.wa.gov/data.json?version=2,no,no
+https://data.oregon.gov/data.json?version=2,no,yes
+https://www.mspb.gov/data.json,yes,yes
+https://data.providenceri.gov/data.json,no,yes
+https://public-chesva.opendata.arcgis.com/data.json,no,no
+https://www.eeoc.gov/data.json,yes,yes
+https://www.ssa.gov/data.json,no,no
+https://www.ftc.gov/data.json,yes,yes
+https://www.nsf.gov/data.json,yes,yes
+https://cwbi-app.sec.usace.army.mil/pub/data.json,no,no
+https://www.nrc.gov/data.json,no,no
+https://data.transportation.gov/data.json,no,no
+https://geospatial-usace.opendata.arcgis.com/data.json,no,no
+https://opendata.maryland.gov/data.json,no,yes
+https://ngda-transportation-geoplatform.hub.arcgis.com/api/feed/dcat-us/1.1.json,no,no
+https://gisportal.ibwc.gov/agsportal/,unknown,fetch error
+https://data.ferndalemi.gov/data.json,no,no
+https://data.tempe.gov/api/feed/dcat-us/1.1.json,no,no
+https://data.arlingtonva.us/data.json,no,no
+https://bloomington.data.socrata.com/data.json,no,yes
+https://data-wake.opendata.arcgis.com/data.json,no,no
+https://data.ntsb.gov/data.json,yes,yes
+https://secure.rrb.gov/data.json,yes,yes
+https://www.dhs.gov/data.json,yes,yes
+https://www.cpsc.gov/data.json,no,no
+https://data.montgomerycountymd.gov/data.json,no,yes
+https://www.nitrd.gov/data.json,yes,yes
+https://www.archive.arm.gov/metadata/data.json,yes,yes
+https://data.usaid.gov/data.json,unknown,fetch error
+https://pbgc.gov/data.json,yes,yes
+https://www.opendataphilly.org/data.json,no,no
+https://www.nist.gov/sites/default/files/data.json,no,no,uses v3.0 reserved `replaces` field name
+https://www.treasury.gov/data.json,yes,yes
+https://pasteur.epa.gov/metadata.json,yes,yes
+https://max.gov/data.json,yes,yes
+https://www.justice.gov/data.json,yes,yes
+https://data.nasa.gov/data.json,no,yes
+https://federallabs.org/data.json,yes,yes
+https://www.sec.gov/data.json,yes,yes
+https://data.lacity.org/data.json,no,yes
+https://nehopendatastorage.blob.core.windows.net/nehopendata/data.json,yes,yes
+https://openei.org/data.json,yes,yes
+https://www.energy.gov/data.json,yes,yes
+https://www.defense.gov/data.json,yes,yes
+https://opendata.cityofboise.org/data.json,no,no
+https://opendata.dc.gov/data.json,no,no
+https://data-lakecountyil.opendata.arcgis.com/data.json,no,no
+https://geodata.vermont.gov/api/feed/dcat-us/1.1.json,no,no
+https://dataworks.siouxfalls.gov/data.json,no,yes
+https://data.srcity.org/data.json,unknown,fetch error
+https://mapcontext.com/npswaf/sample2.json,unknown,fetch error
+https://data.wprdc.org/data.json,no,no
+https://apps.usgs.gov/fgdc/WAF_JSON/combined.json,yes,yes
+https://geocatalog-uidaho.hub.arcgis.com/data.json,no,no
+https://opendurham.nc.gov/data.json,unknown,fetch error
+https://rossi.urs-tally.com/Content/data.json,yes,yes
+https://louisville-metro-opendata-lojic.hub.arcgis.com/api/feed/dcat-us/1.1.json,no,no
+https://raw.githubusercontent.com/gbinal/data/master/datasets/hhs_cas.json,unknown,fetch error
+https://www.loc.gov/data.json,yes,yes

--- a/jsonschema/tests/test_convert.py
+++ b/jsonschema/tests/test_convert.py
@@ -1,0 +1,100 @@
+import csv
+import re
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+CONVERT_SCRIPT = Path(__file__).parent.parent / 'convert_dcat_1_1_to_3_0.py'
+URL_CSV = Path(__file__).parent / 'harvest_source_urls.csv'
+
+# Matches the field name from lines like:
+#   dataset[27].contactPoint: does not match ...
+#   dataset[533].distribution[28].downloadURL: field is not null ...
+#   dataset[56].temporal: expected type ...
+FIELD_ERROR_RE = re.compile(r'dataset\[\d+\](?:\.\w+(?:\[\d+\])?)*\.(\w+):')
+
+
+def load_urls():
+    with open(URL_CSV) as f:
+        reader = csv.DictReader(f)
+        urls = [row['url'] for row in reader]
+        return urls
+
+
+def run_conversion(url):
+    result = subprocess.run(
+        [sys.executable, str(CONVERT_SCRIPT), '--url', url, '--dry-run'],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def categorize_failure(stderr):
+    """Return a top-level failure category and a list of field-level error types."""
+    if 'There was an error fetching' in stderr:
+        if 'DNSError' in stderr:
+            return 'fetch_error:dns', []
+        if 'not valid JSON' in stderr:
+            return 'fetch_error:not_json', []
+        return 'fetch_error:other', []
+    if 'v3.0 validation failed' in stderr:
+        fields = FIELD_ERROR_RE.findall(stderr)
+        return 'validation_failed', fields
+    if 'v1.1 validation failed' in stderr:
+        return 'input_invalid_v1_1', []
+    return 'unknown_error', []
+
+
+def main():
+    urls = load_urls()
+    results = []
+
+    for i, url in enumerate(urls, 1):
+        print(f"[{i}/{len(urls)}] {url}")
+        returncode, stdout, stderr = run_conversion(url)
+        status = "OK" if returncode == 0 else "FAIL"
+        print(f"  {status}")
+        if returncode != 0:
+            print(f"  {stderr.splitlines()[0]}")
+
+        results.append({
+            "url": url,
+            "status": status,
+            "stderr": stderr,
+        })
+
+    # --- Summary ---
+    ok = sum(1 for r in results if r['status'] == 'OK')
+    fail = sum(1 for r in results if r['status'] == 'FAIL')
+    print(f"\n{'='*50}")
+    print(f"Results: {ok} OK, {fail} FAIL out of {len(results)}")
+
+    # Top-level failure categories
+    failure_categories = Counter()
+    field_errors = Counter()  # which fields fail most across all URLs
+    urls_per_field = defaultdict(set)  # which URLs are affected by each field
+
+    for r in results:
+        if r['status'] == 'FAIL':
+            category, fields = categorize_failure(r['stderr'])
+            failure_categories[category] += 1
+            for field in fields:
+                field_errors[field] += 1
+                urls_per_field[field].add(r['url'])
+
+    if failure_categories:
+        print(f"\n--- Failure categories ---")
+        for category, count in failure_categories.most_common():
+            print(f"  {category:<30} {count} URL(s)")
+
+    if field_errors:
+        print(f"\n--- Field errors (by frequency across all datasets) ---")
+        for field, count in field_errors.most_common():
+            url_count = len(urls_per_field[field])
+            print(f"  {field:<30} {count:>6} dataset(s) across {url_count} URL(s)")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
https://github.com/GSA/data.gov/issues/6061

The `convert_dcat_1_1_to_3_0.py` script longer requires valid v1.1 before attempting v3.0 conversion. The previous version of this script halted if v1.1 validation failed.

Status | Count of URLs
-- | --
converts, valid v1.1 | 49
converts, invalid v1.1 | 26
does not convert, invalid v1.1 | 41
fetch error | 12

Adds a script to run conversion against all harvest source URLs and summarize results.