### PR TITLE
Feature/dataset series bugfix

### DIFF
--- a/jsonschema/create_null_examples.py
+++ b/jsonschema/create_null_examples.py
@@ -36,6 +36,16 @@ SCHEMA_STARTERS = {
         "title": "",
         "contactPoint": {"hasEmail": "mailto:a@example.gov", "fn": ""},
     },
+    "Catalog": {
+        "dataset": [
+            {
+                "description": "",
+                "title": "",
+                "contactPoint": {"hasEmail": "mailto:a@example.gov", "fn": ""},
+                "identifier": "",
+            }
+        ]
+    },
     "DatasetSeries": {"description": "", "title": ""},
     "Distribution": {},
     "Document": {"title": ""},

--- a/jsonschema/definitions/Catalog.json
+++ b/jsonschema/definitions/Catalog.json
@@ -545,6 +545,7 @@
       ],
       "datasetSeries": [
         {
+          "@id": "https://example.gov/series/annual-climate-observations",
           "@type": "DatasetSeries",
           "title": "Annual Climate Observations",
           "description": "A series of annual climate observation datasets from monitoring stations.",

--- a/jsonschema/definitions/Catalog.json
+++ b/jsonschema/definitions/Catalog.json
@@ -53,6 +53,15 @@
       },
       "requirementLevel": "Mandatory"
     },
+    "datasetSeries": {
+      "title": "dataset series",
+      "description": "List of dataset series included in the catalog.",
+      "type": ["null", "array"],
+      "items": {
+        "$ref": "/dcat-us/3.0.0/definitions/datasetseries"
+      },
+      "requirementLevel": "Optional"
+    },
     "keyword": {
       "title": "keyword/tag",
       "description": "List of keywords or tags describing the catalog",
@@ -532,6 +541,31 @@
             "name": "National Climate Data Center"
           },
           "identifier": "https://example.gov/datasets/climate-observations-1"
+        }
+      ],
+      "datasetSeries": [
+        {
+          "@type": "DatasetSeries",
+          "title": "Annual Climate Observations",
+          "description": "A series of annual climate observation datasets from monitoring stations.",
+          "publisher": {
+            "name": "National Climate Data Center"
+          },
+          "seriesMember": [
+            {
+              "@type": "Dataset",
+              "title": "Daily Climate Observations 2024",
+              "description": "Daily temperature, precipitation, and wind measurements.",
+              "contactPoint": {
+                "fn": "Climate Data Support",
+                "hasEmail": "mailto:climate@example.gov"
+              },
+              "publisher": {
+                "name": "National Climate Data Center"
+              },
+              "identifier": "https://example.gov/datasets/climate-observations-1"
+            }
+          ]
         }
       ],
       "homepage": {

--- a/jsonschema/definitions/Dataset.json
+++ b/jsonschema/definitions/Dataset.json
@@ -163,19 +163,6 @@
         "uri": "dcat:hasVersion"
       }
     },
-    "inSeries": {
-      "title": "in series",
-      "description": "Dataset series this dataset belongs to",
-      "type": ["null", "array"],
-      "items": {
-        "$ref": "/dcat-us/3.0.0/definitions/datasetseries"
-      },
-      "_oldDocs": {
-        "uri": "dcat:inSeries",
-        "range": "dcat:DatasetSeries"
-      },
-      "requirementLevel": "Optional"
-    },
     "keyword": {
       "title": "keyword/tag",
       "description": "List of keywords or tags describing the dataset",

--- a/jsonschema/definitions/DatasetSeries.json
+++ b/jsonschema/definitions/DatasetSeries.json
@@ -8,7 +8,8 @@
     "@id": {
       "type": "string",
       "format": "iri",
-      "examples": ["https://example.gov/series/annual-climate-observations"]
+      "examples": ["https://example.gov/series/annual-climate-observations"],
+      "requirementLevel": "Recommended"
     },
     "@type": {
       "type": "string",
@@ -305,6 +306,7 @@
   },
   "examples": [
     {
+      "@id": "https://example.gov/series/annual-climate-observations",
       "@type": "DatasetSeries",
       "title": "Annual Climate Observations",
       "description": "A series of annual climate observation datasets from monitoring stations.",

--- a/jsonschema/docs/catalog.md
+++ b/jsonschema/docs/catalog.md
@@ -36,6 +36,7 @@ A curated collection of metadata about datasets, data services, or other resourc
     ],
     "datasetSeries": [
         {
+            "@id": "https://example.gov/series/annual-climate-observations",
             "@type": "DatasetSeries",
             "title": "Annual Climate Observations",
             "description": "A series of annual climate observation datasets from monitoring stations.",

--- a/jsonschema/docs/catalog.md
+++ b/jsonschema/docs/catalog.md
@@ -34,6 +34,31 @@ A curated collection of metadata about datasets, data services, or other resourc
             "identifier": "https://example.gov/datasets/climate-observations-1"
         }
     ],
+    "datasetSeries": [
+        {
+            "@type": "DatasetSeries",
+            "title": "Annual Climate Observations",
+            "description": "A series of annual climate observation datasets from monitoring stations.",
+            "publisher": {
+                "name": "National Climate Data Center"
+            },
+            "seriesMember": [
+                {
+                    "@type": "Dataset",
+                    "title": "Daily Climate Observations 2024",
+                    "description": "Daily temperature, precipitation, and wind measurements.",
+                    "contactPoint": {
+                        "fn": "Climate Data Support",
+                        "hasEmail": "mailto:climate@example.gov"
+                    },
+                    "publisher": {
+                        "name": "National Climate Data Center"
+                    },
+                    "identifier": "https://example.gov/datasets/climate-observations-1"
+                }
+            ]
+        }
+    ],
     "homepage": {
         "@type": "Document",
         "title": "National Climate Data Catalog Homepage",
@@ -84,6 +109,7 @@ A curated collection of metadata about datasets, data services, or other resourc
 | [category](#category)                         | null or array of [Concept](./identifiers-and-relationships.md#concept) classes              | Optional          | List of high-level categories for the catalog                                                                                         |
 | [contactPoint](#contactPoint)                 | null or array of [Kind](./agents.md#kind) classes                                           | Optional          | Contact information people can use to ask questions or send feedback about the catalog                                                |
 | [creator](#creator)                           | null or array of [Agent](./agents.md#agent) classes                                         | Optional          | Person or organization responsible for creating the catalog metadata                                                                  |
+| [datasetSeries](#datasetSeries)               | null or array of [DatasetSeries](./dataset-series.md#root) classes                          | Optional          | List of dataset series included in the catalog.                                                                                       |
 | [description](#description)                   | null or string                                                                              | Optional          | Plain-language summary of the catalog                                                                                                 |
 | [hasPart](#hasPart)                           | null or array of object                                                                     | Optional          | List of catalogs that are contained within this catalog                                                                               |
 | [identifier](#identifier)                     | null or [Identifier](./identifiers-and-relationships.md#identifier)                         | Optional          | Main unique identifier for the catalog, such as a URI or another persistent identifier                                                |
@@ -379,6 +405,17 @@ Person or organization responsible for creating the catalog metadata
 
 **Each item of this array must be:**
 - [Agent](./agents.md#agent): A person, organization, software agent, or other entity involved with a resource
+
+## <a name="datasetSeries"></a>`DCAT-US 3 Catalog > datasetSeries` [#](#datasetSeries)
+
+**Requirement:** Optional
+
+List of dataset series included in the catalog.
+
+- **Type**: null or array of [DatasetSeries](./dataset-series.md#root) classes
+
+**Each item of this array must be:**
+- [DatasetSeries](./dataset-series.md#root): A group of related datasets that are published separately
 
 ## <a name="description"></a>`DCAT-US 3 Catalog > description` [#](#description)
 

--- a/jsonschema/docs/dataset-series.md
+++ b/jsonschema/docs/dataset-series.md
@@ -11,6 +11,7 @@ A group of related datasets that are published separately
 
 ```json
 {
+    "@id": "https://example.gov/series/annual-climate-observations",
     "@type": "DatasetSeries",
     "title": "Annual Climate Observations",
     "description": "A series of annual climate observation datasets from monitoring stations.",
@@ -144,6 +145,7 @@ A group of related datasets that are published separately
 | ------------------------------------------ | ------------------------------------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | [description](#description)               | string                                                                                | Mandatory         | Plain-language summary of the dataset series                                                                                             |
 | [title](#title)                           | string                                                                                | Mandatory         | Human-readable title of the dataset series                                                                                               |
+| [@id](#@id)                               | string                                                                                | Recommended       |                                                                                                                                          |
 | [contactPoint](#contactPoint)             | null or array of [Kind](./agents.md#kind) classes                                     | Recommended       | List of contacts people can use to ask questions or send feedback about the dataset series                                               |
 | [first](#first)                           | null or [Dataset](./dataset.md#root)                                                  | Recommended       | The first dataset in an ordered dataset series                                                                                           |
 | [last](#last)                             | null or [Dataset](./dataset.md#root)                                                  | Recommended       | The last dataset in an ordered dataset series                                                                                            |
@@ -152,7 +154,6 @@ A group of related datasets that are published separately
 | [seriesMember](#seriesMember)             | null or array of [Dataset](./dataset.md#root) classes                                 | Recommended       | List of members of the Dataset Series                                                                                                    |
 | [spatial](#spatial)                       | null or array of [Location](./temporal-spatial-metrics.md#location) classes           | Recommended       | A geographic region that is covered by the Dataset Series                                                                                |
 | [temporal](#temporal)                     | null or array of [PeriodOfTime](./temporal-spatial-metrics.md#period-of-time) classes | Recommended       | Time periods covered by the dataset series                                                                                               |
-| [@id](#@id)                               | string                                                                                | Optional          |                                                                                                                                          |
 | [@type](#@type)                           | string                                                                                | Optional          |                                                                                                                                          |
 | [accrualPeriodicity](#accrualPeriodicity) | More than one type                                                                    | Optional          | The frequency at which the Dataset Series is updated. This is the series update frequency, not necessarily each dataset's frequency      |
 | [issued](#issued)                         | null or object                                                                        | Optional          | Date when the Dataset Series was formally established or published, not the release date of the oldest dataset in the series             |
@@ -189,6 +190,19 @@ Human-readable title of the dataset series
 
 ```json
 "Annual National Climate Observations Series"
+```
+
+## <a name="@id"></a>`DatasetSeries > @id` [#](#@id)
+
+**Requirement:** Recommended
+
+- **Type**: `string`
+- **Format**: `iri`
+
+**Example:**
+
+```json
+"https://example.gov/series/annual-climate-observations"
 ```
 
 ## <a name="contactPoint"></a>`DatasetSeries > contactPoint` [#](#contactPoint)
@@ -294,19 +308,6 @@ Time periods covered by the dataset series
 
 **Each item of this array must be:**
 - [PeriodOfTime](./temporal-spatial-metrics.md#period-of-time): Information about a specific time period with a start- and/or end-time
-
-## <a name="@id"></a>`DatasetSeries > @id` [#](#@id)
-
-**Requirement:** Optional
-
-- **Type**: `string`
-- **Format**: `iri`
-
-**Example:**
-
-```json
-"https://example.gov/series/annual-climate-observations"
-```
 
 ## <a name="@type"></a>`DatasetSeries > @type` [#](#@type)
 

--- a/jsonschema/docs/dataset.md
+++ b/jsonschema/docs/dataset.md
@@ -132,7 +132,6 @@ A collection of data published or curated by one provider
 | [hasQualityMeasurement](#hasQualityMeasurement)         | null or array of [QualityMeasurement](./temporal-spatial-metrics.md#quality-measurement) classes   | Optional          | List of quality measurements for the dataset (for example, completeness, accuracy, or timeliness) beyond spatial or temporal resolution                                                                                                                    |
 | [hasVersion](#hasVersion)                               | null or array of [Dataset](./dataset.md#root) classes                                              | Optional          | List of related Datasets that are a version, edition, or adaptation of the described Dataset                                                                                                                                                               |
 | [image](#image)                                         | null or string                                                                                     | Optional          | Thumbnail image illustrating the dataset, especially useful for visual data such as maps, photos, or video                                                                                                                                                 |
-| [inSeries](#inSeries)                                   | null or array of [DatasetSeries](./dataset-series.md#root) classes                                 | Optional          | Dataset series this dataset belongs to                                                                                                                                                                                                                     |
 | [isReferencedBy](#isReferencedBy)                       | null or array of string                                                                            | Optional          | List of links to related resources, such as publications, that reference, cite, or otherwise point to the Dataset                                                                                                                                          |
 | [issued](#issued)                                       | null or object                                                                                     | Optional          | Date when the dataset was first published. If the exact publication date is unknown, use the date it was first referenced in the catalog.                                                                                                                  |
 | [language](#language)                                   | More than one type                                                                                 | Optional          | ISO 639-1 language code values used in the dataset text or metadata, such as en or es, full list can be seen at https://id.loc.gov/vocabulary/iso639-1.html                                                                                                |
@@ -760,17 +759,6 @@ List of related Datasets that are a version, edition, or adaptation of the descr
 Thumbnail image illustrating the dataset, especially useful for visual data such as maps, photos, or video
 
 - **Type**: null or string
-
-## <a name="inSeries"></a>`Dataset > inSeries` [#](#inSeries)
-
-**Requirement:** Optional
-
-Dataset series this dataset belongs to
-
-- **Type**: null or array of [DatasetSeries](./dataset-series.md#root) classes
-
-**Each item of this array must be:**
-- [DatasetSeries](./dataset-series.md#root): A group of related datasets that are published separately
 
 ## <a name="isReferencedBy"></a>`Dataset > isReferencedBy` [#](#isReferencedBy)
 

--- a/jsonschema/examples/Catalog/good/complete_example.json
+++ b/jsonschema/examples/Catalog/good/complete_example.json
@@ -150,6 +150,7 @@
   ],
   "datasetSeries": [
     {
+      "@id": "https://example.gov/series/federal-budget-data-series",
       "@type": "DatasetSeries",
       "title": "Federal Budget Data Series",
       "description": "A series of federal budget datasets published by fiscal year.",

--- a/jsonschema/examples/Catalog/good/complete_example.json
+++ b/jsonschema/examples/Catalog/good/complete_example.json
@@ -148,6 +148,31 @@
       "identifier": "https://example.gov/datasets/catalog-complete-002"
     }
   ],
+  "datasetSeries": [
+    {
+      "@type": "DatasetSeries",
+      "title": "Federal Budget Data Series",
+      "description": "A series of federal budget datasets published by fiscal year.",
+      "publisher": {
+        "name": "Office of Management and Budget"
+      },
+      "seriesMember": [
+        {
+          "@type": "Dataset",
+          "title": "Annual Budget Data",
+          "description": "Federal budget allocations and expenditures by agency and fiscal year.",
+          "contactPoint": {
+            "fn": "Budget Data Team",
+            "hasEmail": "mailto:budget@example.gov"
+          },
+          "publisher": {
+            "name": "Office of Management and Budget"
+          },
+          "identifier": "https://example.gov/datasets/catalog-complete-001"
+        }
+      ]
+    }
+  ],
   "service": [
     {
       "@type": "DataService",

--- a/jsonschema/examples/Catalog/good/typical_example.json
+++ b/jsonschema/examples/Catalog/good/typical_example.json
@@ -24,6 +24,7 @@
   ],
   "datasetSeries": [
     {
+      "@id": "https://example.gov/series/annual-climate-observations",
       "@type": "DatasetSeries",
       "title": "Annual Climate Observations",
       "description": "A series of annual climate observation datasets from monitoring stations.",

--- a/jsonschema/examples/Catalog/good/typical_example.json
+++ b/jsonschema/examples/Catalog/good/typical_example.json
@@ -22,6 +22,31 @@
       "identifier": "https://example.gov/datasets/climate-observations-1"
     }
   ],
+  "datasetSeries": [
+    {
+      "@type": "DatasetSeries",
+      "title": "Annual Climate Observations",
+      "description": "A series of annual climate observation datasets from monitoring stations.",
+      "publisher": {
+        "name": "National Climate Data Center"
+      },
+      "seriesMember": [
+        {
+          "@type": "Dataset",
+          "title": "Daily Climate Observations 2024",
+          "description": "Daily temperature, precipitation, and wind measurements.",
+          "contactPoint": {
+            "fn": "Climate Data Support",
+            "hasEmail": "mailto:climate@example.gov"
+          },
+          "publisher": {
+            "name": "National Climate Data Center"
+          },
+          "identifier": "https://example.gov/datasets/climate-observations-1"
+        }
+      ]
+    }
+  ],
   "homepage": {
     "@type": "Document",
     "title": "National Climate Data Catalog Homepage",

--- a/jsonschema/examples/Dataset/good/complete_example.json
+++ b/jsonschema/examples/Dataset/good/complete_example.json
@@ -220,14 +220,6 @@
   ],
   "purpose": "To provide comprehensive, high-quality climate observations for research, planning, and decision-making related to weather and climate.",
   "liabilityStatement": "This dataset is provided as-is without warranty of any kind. Users are responsible for determining fitness for their intended use.",
-  "inSeries": [
-    {
-      "@id": "https://example.gov/series/annual-climate-observations",
-      "@type": "DatasetSeries",
-      "title": "Annual Climate Observations Series",
-      "description": "An annual series of national climate observations datasets."
-    }
-  ],
   "previousVersion": {
     "@id": "https://example.gov/datasets/national-climate-observations-2023",
     "@type": "Dataset",

--- a/jsonschema/examples/Dataset/good/comprehensive-dataset.json
+++ b/jsonschema/examples/Dataset/good/comprehensive-dataset.json
@@ -146,46 +146,6 @@
       "identifier": "https://example.gov/datasets/nested-version-003"
     }
   ],
-  "inSeries": [
-    {
-      "@id": "https://example.gov/series/comprehensive-series",
-      "@type": "DatasetSeries",
-      "title": "Comprehensive Dataset Series",
-      "description": "A series of comprehensive example datasets demonstrating DCAT-US 3.0 schema",
-      "contactPoint": [
-        {
-          "@id": "https://example.gov/contacts/series-contact",
-          "@type": "Kind",
-          "fn": "Series Manager",
-          "hasEmail": "mailto:series@example.gov"
-        }
-      ],
-      "first": {
-        "description": "A minimal dataset",
-        "publisher": {
-          "name": "The Minimal Organization"
-        },
-        "title": "Dataset One",
-        "contactPoint": {
-          "hasEmail": "mailto:example@example.gov",
-          "fn": "Example contact"
-        },
-        "identifier": "https://example.gov/datasets/nested-series-first-004"
-      },
-      "last": {
-        "description": "A minimal dataset",
-        "publisher": {
-          "name": "The Minimal Organization"
-        },
-        "title": "Dataset One",
-        "contactPoint": {
-          "hasEmail": "mailto:example@example.gov",
-          "fn": "Example contact"
-        },
-        "identifier": "https://example.gov/datasets/nested-series-last-005"
-      }
-    }
-  ],
   "keyword": [
     "government",
     "open data",

--- a/jsonschema/examples/Dataset/good/null_example.json
+++ b/jsonschema/examples/Dataset/good/null_example.json
@@ -20,7 +20,6 @@
   "hasVersion": null,
   "identifier": "",
   "image": null,
-  "inSeries": null,
   "inventoried": null,
   "isReferencedBy": null,
   "issued": null,

--- a/jsonschema/examples/DatasetSeries/good/good-accrual-periodicity.json
+++ b/jsonschema/examples/DatasetSeries/good/good-accrual-periodicity.json
@@ -1,4 +1,5 @@
 {
+  "@id": "https://example.gov/series/example-dataset-series-quarterly",
   "@type": "DatasetSeries",
   "title": "Example Dataset Series",
   "description": "A minimal dataset series example with valid periodicity",

--- a/jsonschema/examples/DatasetSeries/good/minimal_example.json
+++ b/jsonschema/examples/DatasetSeries/good/minimal_example.json
@@ -1,4 +1,5 @@
 {
+  "@id": "https://example.gov/series/example-dataset-series-minimal",
   "title": "Example Dataset Series",
   "description": "A series of datasets for testing purposes."
 }

--- a/jsonschema/examples/DatasetSeries/good/null_example.json
+++ b/jsonschema/examples/DatasetSeries/good/null_example.json
@@ -1,4 +1,5 @@
 {
+  "@id": "https://example.gov/series/example-dataset-series-null",
   "accrualPeriodicity": null,
   "contactPoint": null,
   "description": "",

--- a/jsonschema/examples/DatasetSeries/good/typical_example.json
+++ b/jsonschema/examples/DatasetSeries/good/typical_example.json
@@ -1,4 +1,5 @@
 {
+  "@id": "https://example.gov/series/annual-climate-observations",
   "@type": "DatasetSeries",
   "title": "Annual Climate Observations",
   "description": "A series of annual climate observation datasets from monitoring stations.",


### PR DESCRIPTION
## Problem we are trying to solve

This fixes (as discussed) the concerning issue of datasetSeries reference looping (dataset can reference a datasetSeries, which can have a list of datasets, which can each have a datasetSeries, and so on) and possible duplicate references, as well as child defining the datasetSeries being defined only once and then listing it's children.

## Proposed solution

This now defines a top level catalog field called `datasetSeries`, which is a list of the DatasetSeries class. Each of these records has some high level metadata about the series, and a field called `seriesMember` that is a list of all datasets within the series.

Datasets can no longer define a series that they are within using the `inSeries` field, that has been removed.

### Notes

This does add the `@id` field to be "Recommended" and includes that field in all examples. Since DatasetSeries doesn't include an identifier reference as being required, this is the closest thing to help data.gov keep all the series straight (they fall back to a munged title if no identifier). This has no real change to the schema, really only to the documentation and showcasing how we want people to implement this, so I felt safe including this. Adding an identifier and making it required will require further discussion and iteration.