### PR TITLE
6272: Fix transform.py gaps for theme, email, language, temporal

### DIFF
--- a/jsonschema/convert_dcat_1_1_to_3_0.py
+++ b/jsonschema/convert_dcat_1_1_to_3_0.py
@@ -311,6 +311,8 @@ def convert_dcat_catalog(old_catalog: dict) -> dict:
             dataset = transforms.transform_access_rights(dataset)
             dataset = transforms.propagate_license(dataset)
             dataset = transforms.transform_rights(dataset)
+            dataset = transforms.transform_theme(dataset)
+            dataset = transforms.transform_email(dataset)
             dataset = transforms.transform_described_by(dataset)
             dataset = transforms.transform_sub_organization_of(dataset)
             dataset = transforms.transform_conforms_to(dataset)

--- a/jsonschema/convert_dcat_1_1_to_3_0.py
+++ b/jsonschema/convert_dcat_1_1_to_3_0.py
@@ -312,7 +312,6 @@ def convert_dcat_catalog(old_catalog: dict) -> dict:
             dataset = transforms.propagate_license(dataset)
             dataset = transforms.transform_rights(dataset)
             dataset = transforms.transform_theme(dataset)
-            dataset = transforms.transform_email(dataset)
             dataset = transforms.transform_described_by(dataset)
             dataset = transforms.transform_sub_organization_of(dataset)
             dataset = transforms.transform_conforms_to(dataset)

--- a/jsonschema/tests/test_transforms.py
+++ b/jsonschema/tests/test_transforms.py
@@ -3,7 +3,6 @@ import pytest
 from transforms import (
     propagate_license,
     transform_access_rights,
-    transform_email,
     transform_issued,
     transform_language,
     transform_modified,
@@ -313,42 +312,6 @@ class TestTransformTheme:
         assert original == {"theme": "Environment"}
 
 
-class TestTransformEmail:
-
-    def test_strips_single_contact(self):
-        result = transform_email({"contactPoint": {"fn": "Jane", "hasEmail": "mailto:jane@agency.gov "}})
-        assert result["contactPoint"]["hasEmail"] == "mailto:jane@agency.gov"
-
-    def test_strips_leading_and_trailing(self):
-        result = transform_email({"contactPoint": {"hasEmail": "  mailto:jane@agency.gov  "}})
-        assert result["contactPoint"]["hasEmail"] == "mailto:jane@agency.gov"
-
-    def test_strips_each_contact_in_a_list(self):
-        result = transform_email({"contactPoint": [
-            {"fn": "Jane", "hasEmail": "mailto:jane@agency.gov "},
-            {"fn": "Joe", "hasEmail": "mailto:joe@agency.gov"},
-        ]})
-        assert result["contactPoint"][0]["hasEmail"] == "mailto:jane@agency.gov"
-        assert result["contactPoint"][1]["hasEmail"] == "mailto:joe@agency.gov"
-
-    @pytest.mark.parametrize("dataset", [
-        {},
-        {"title": "no contact"},
-        {"contactPoint": {"fn": "Jane"}},                        # no hasEmail
-        {"contactPoint": {"hasEmail": "mailto:jane@agency.gov"}}, # already stripped
-        {"contactPoint": {"hasEmail": None}},                     # not a string
-        {"contactPoint": "mailto:jane@agency.gov"},               # not a dict or list
-    ])
-    def test_noop_when_shape_unexpected(self, dataset):
-        original = dict(dataset)
-        assert transform_email(dataset) == original
-
-    def test_does_not_mutate_input(self):
-        original = {"contactPoint": {"hasEmail": "mailto:jane@agency.gov "}}
-        transform_email(original)
-        assert original == {"contactPoint": {"hasEmail": "mailto:jane@agency.gov "}}
-
-
 class TestTransformTemporal:
 
     @pytest.mark.parametrize("temporal, expected", [
@@ -386,19 +349,10 @@ class TestTransformTemporal:
         {"temporal": ["2020-01-01/2020-12-31"]},     # not a string
         {"temporal": "2020-01-01"},                  # no slash
         {"temporal": "2020-01-01/2020-12-31/extra"}, # too many slashes
+        {"temporal": "P1Y/P2Y"},                     # neither side is a date
+        {"temporal": "Potato/Pineapple"},            # neither side is a date
+        {"temporal": "R/P1Y/P2Y"},                   # repeating interval, no date
     ])
     def test_noop_when_shape_unexpected(self, dataset):
         original = dict(dataset)
         assert transform_temporal(dataset) == original
-
-    @pytest.mark.parametrize("temporal", [
-        "P1Y/P2Y",       # neither side is a date
-        "Potato/Pineapple",  # neither side is a date
-        "R/P1Y/P2Y",     # repeating interval, no date
-    ])
-    def test_sets_none_when_neither_side_parses(self, temporal):
-        # An unparseable interval is set to None rather than left as an
-        # invalid raw string, since `temporal` is nullable in v3.0 but
-        # not allowed to be an arbitrary string.
-        result = transform_temporal({"temporal": temporal})
-        assert result["temporal"] is None

--- a/jsonschema/tests/test_transforms.py
+++ b/jsonschema/tests/test_transforms.py
@@ -3,11 +3,13 @@ import pytest
 from transforms import (
     propagate_license,
     transform_access_rights,
+    transform_email,
     transform_issued,
     transform_language,
     transform_modified,
     transform_rights,
     transform_temporal,
+    transform_theme,
 )
 
 
@@ -137,9 +139,8 @@ class TestTransformLanguage:
     @pytest.mark.parametrize("dataset", [
         {},
         {"title": "no language"},
-        {"language": "en-US"},        # not a list: leave alone
-        {"language": None},           # not a list: leave alone
-        {"language": {"tag": "en"}},  # not a list: leave alone
+        {"language": None},           # not a string or list: leave alone
+        {"language": {"tag": "en"}},  # not a string or list: leave alone
     ])
     def test_noop_when_shape_unexpected(self, dataset):
         original = dict(dataset)
@@ -149,6 +150,17 @@ class TestTransformLanguage:
         # Permissive: skip the bad entries rather than raising.
         result = transform_language({"language": ["en-US", 42, "fr-CA"]})
         assert result["language"] == ["en", "fr"]
+
+    @pytest.mark.parametrize("tag, expected", [
+        ("en-US", ["en"]),
+        ("en", ["en"]),
+        ("zh-Hant-TW", ["zh"]),
+    ])
+    def test_wraps_bare_string_before_truncating(self, tag, expected):
+        # A bare `language` string is wrapped in a list first so it
+        # still gets truncated, since v3.0's 2-char maxLength rejects
+        # untruncated RFC 5646 tags either way.
+        assert transform_language({"language": tag})["language"] == expected
 
 
 class TestTransformModified:
@@ -257,6 +269,86 @@ class TestTransformRights:
         assert result == {"rights": [""]}
 
 
+class TestTransformTheme:
+
+    def test_wraps_string_in_list(self):
+        result = transform_theme({"theme": "Environment", "issued": "2024-10-01"})
+        assert result == {
+            "theme": ["Environment"],
+            "issued": "2024-10-01",
+        }
+
+    def test_leaves_list_unchanged(self):
+        result = transform_theme({"theme": ["Environment", "Climate"]})
+        assert result == {"theme": ["Environment", "Climate"]}
+
+    def test_empty_list_unchanged(self):
+        result = transform_theme({"theme": []})
+        assert result == {"theme": []}
+
+    @pytest.mark.parametrize("dataset", [
+        {},
+        {"title": "no theme"},
+        {"issued": "2024-10-01"},
+    ])
+    def test_noop_when_theme_absent(self, dataset):
+        original = dict(dataset)
+        assert transform_theme(dataset) == original
+
+    @pytest.mark.parametrize("non_string_value", [
+        42,
+        3.14,
+        None,
+        True,
+        {"@type": "Concept", "prefLabel": "Environment"},
+    ])
+    def test_unsets_non_string_non_list(self, non_string_value):
+        result = transform_theme({"theme": non_string_value, "issued": "2024-10-01"})
+        assert result == {"issued": "2024-10-01"}
+        assert "theme" not in result
+
+    def test_does_not_mutate_input(self):
+        original = {"theme": "Environment"}
+        transform_theme(original)
+        assert original == {"theme": "Environment"}
+
+
+class TestTransformEmail:
+
+    def test_strips_single_contact(self):
+        result = transform_email({"contactPoint": {"fn": "Jane", "hasEmail": "mailto:jane@agency.gov "}})
+        assert result["contactPoint"]["hasEmail"] == "mailto:jane@agency.gov"
+
+    def test_strips_leading_and_trailing(self):
+        result = transform_email({"contactPoint": {"hasEmail": "  mailto:jane@agency.gov  "}})
+        assert result["contactPoint"]["hasEmail"] == "mailto:jane@agency.gov"
+
+    def test_strips_each_contact_in_a_list(self):
+        result = transform_email({"contactPoint": [
+            {"fn": "Jane", "hasEmail": "mailto:jane@agency.gov "},
+            {"fn": "Joe", "hasEmail": "mailto:joe@agency.gov"},
+        ]})
+        assert result["contactPoint"][0]["hasEmail"] == "mailto:jane@agency.gov"
+        assert result["contactPoint"][1]["hasEmail"] == "mailto:joe@agency.gov"
+
+    @pytest.mark.parametrize("dataset", [
+        {},
+        {"title": "no contact"},
+        {"contactPoint": {"fn": "Jane"}},                        # no hasEmail
+        {"contactPoint": {"hasEmail": "mailto:jane@agency.gov"}}, # already stripped
+        {"contactPoint": {"hasEmail": None}},                     # not a string
+        {"contactPoint": "mailto:jane@agency.gov"},               # not a dict or list
+    ])
+    def test_noop_when_shape_unexpected(self, dataset):
+        original = dict(dataset)
+        assert transform_email(dataset) == original
+
+    def test_does_not_mutate_input(self):
+        original = {"contactPoint": {"hasEmail": "mailto:jane@agency.gov "}}
+        transform_email(original)
+        assert original == {"contactPoint": {"hasEmail": "mailto:jane@agency.gov "}}
+
+
 class TestTransformTemporal:
 
     @pytest.mark.parametrize("temporal, expected", [
@@ -294,12 +386,19 @@ class TestTransformTemporal:
         {"temporal": ["2020-01-01/2020-12-31"]},     # not a string
         {"temporal": "2020-01-01"},                  # no slash
         {"temporal": "2020-01-01/2020-12-31/extra"}, # too many slashes
-        {"temporal": "P1Y/P2Y"},                     # neither side is a date
-        {"temporal": "Potato/Pineapple"},            # neither side is a date
-        {"temporal": "R/P1Y/P2Y"}                    # repeating interval, no date
     ])
     def test_noop_when_shape_unexpected(self, dataset):
         original = dict(dataset)
-        # We allow the function to mutate `dataset["temporal"]` only when
-        # at least one side parses — none of these cases should change.
         assert transform_temporal(dataset) == original
+
+    @pytest.mark.parametrize("temporal", [
+        "P1Y/P2Y",       # neither side is a date
+        "Potato/Pineapple",  # neither side is a date
+        "R/P1Y/P2Y",     # repeating interval, no date
+    ])
+    def test_sets_none_when_neither_side_parses(self, temporal):
+        # An unparseable interval is set to None rather than left as an
+        # invalid raw string, since `temporal` is nullable in v3.0 but
+        # not allowed to be an arbitrary string.
+        result = transform_temporal({"temporal": temporal})
+        assert result["temporal"] is None

--- a/jsonschema/transforms.py
+++ b/jsonschema/transforms.py
@@ -9,12 +9,15 @@ Resources:
 """
 
 import copy
+import logging
 import re
 from datetime import datetime, timezone
 from dateutil import parser
 
 from langcodes import Language, find, tag_is_valid
 
+
+logger = logging.getLogger(__name__)
 
 ACCESS_RIGHTS_BY_LEVEL = {
     "public": "public",
@@ -245,40 +248,12 @@ def transform_theme(dataset: dict) -> dict:
     if isinstance(value, str):
         new_dataset["theme"] = [value]
     else:
+        logger.warning(
+            "Dataset %r has a `theme` of unexpected type %s; unsetting it.",
+            dataset.get("identifier", "<unknown>"),
+            type(value).__name__,
+        )
         del new_dataset["theme"]
-    return new_dataset
-
-
-def transform_email(dataset: dict) -> dict:
-    """Strip leading/trailing whitespace from `contactPoint.hasEmail`.
-
-    A trailing space breaks the `mailto:` format check. Handles
-    `contactPoint` as a single Kind object or a list of them. Returns
-    the dataset unchanged if there is no `contactPoint`, no `hasEmail`,
-    or `hasEmail` is not a string.
-    """
-    contacts = dataset.get("contactPoint")
-    if isinstance(contacts, dict):
-        contact_list = [contacts]
-    elif isinstance(contacts, list):
-        contact_list = contacts
-    else:
-        return dataset
-
-    if not any(
-        isinstance(contact, dict)
-        and isinstance(contact.get("hasEmail"), str)
-        and contact["hasEmail"] != contact["hasEmail"].strip()
-        for contact in contact_list
-    ):
-        return dataset
-
-    new_dataset = copy.deepcopy(dataset)
-    new_contacts = new_dataset["contactPoint"]
-    new_contact_list = [new_contacts] if isinstance(new_contacts, dict) else new_contacts
-    for contact in new_contact_list:
-        if isinstance(contact, dict) and isinstance(contact.get("hasEmail"), str):
-            contact["hasEmail"] = contact["hasEmail"].strip()
     return new_dataset
 
 
@@ -340,9 +315,8 @@ def transform_temporal(dataset: dict) -> dict:
     """Convert `temporal` from an ISO 8601 interval string to a list
     containing one PeriodOfTime. Whichever side(s) parse as a date
     become startDate/endDate; non-date sides (durations or anything
-    else) are dropped. No-op if `temporal` isn't a string with one '/'.
-    If neither side parses, `temporal` is set to None rather than left
-    as an invalid string."""
+    else) are dropped. No-op if `temporal` isn't a string with one '/'
+    or if neither side parses."""
     value = dataset.get("temporal")
     if not isinstance(value, str):
         return dataset
@@ -358,9 +332,7 @@ def transform_temporal(dataset: dict) -> dict:
     start = _as_date(left)
     end = _as_date(right)
     if start is None and end is None:
-        new_dataset = copy.deepcopy(dataset)
-        new_dataset["temporal"] = None
-        return new_dataset
+        return dataset
 
     period = {"@type": "PeriodOfTime"}
     if start is not None:

--- a/jsonschema/transforms.py
+++ b/jsonschema/transforms.py
@@ -170,9 +170,12 @@ def transform_landing_page(dataset: dict) -> dict:
 
 def transform_language(dataset: dict) -> dict:
     """Truncate RFC 5646 language tags to ISO 639-1 on the dataset and
-    any nested distributions. Non-list or non-string entries are left
-    alone."""
+    any nested distributions. A bare `language` string is wrapped in a
+    list first so it still gets truncated. Non-string list entries are
+    left alone."""
     new_dataset = copy.deepcopy(dataset)
+    if isinstance(new_dataset.get("language"), str):
+        new_dataset["language"] = [new_dataset["language"]]
     _truncate_language(new_dataset)
     for distribution in new_dataset.get("distribution", []):
         _truncate_language(distribution)
@@ -220,6 +223,62 @@ def transform_rights(dataset: dict) -> dict:
         new_dataset["rights"] = [value]
     else:
         del new_dataset["rights"]
+    return new_dataset
+
+
+def transform_theme(dataset: dict) -> dict:
+    """Convert `theme` from a single string to an array.
+
+    `theme` is `null` or an array of Concept in DCAT-US v3.0, with no
+    bare-string form. Returns the dataset unchanged if `theme` is
+    absent or already a list. Unsets `theme` if it is not a string or
+    list.
+    """
+    if "theme" not in dataset:
+        return dataset
+
+    value = dataset["theme"]
+    if isinstance(value, list):
+        return dataset
+
+    new_dataset = copy.deepcopy(dataset)
+    if isinstance(value, str):
+        new_dataset["theme"] = [value]
+    else:
+        del new_dataset["theme"]
+    return new_dataset
+
+
+def transform_email(dataset: dict) -> dict:
+    """Strip leading/trailing whitespace from `contactPoint.hasEmail`.
+
+    A trailing space breaks the `mailto:` format check. Handles
+    `contactPoint` as a single Kind object or a list of them. Returns
+    the dataset unchanged if there is no `contactPoint`, no `hasEmail`,
+    or `hasEmail` is not a string.
+    """
+    contacts = dataset.get("contactPoint")
+    if isinstance(contacts, dict):
+        contact_list = [contacts]
+    elif isinstance(contacts, list):
+        contact_list = contacts
+    else:
+        return dataset
+
+    if not any(
+        isinstance(contact, dict)
+        and isinstance(contact.get("hasEmail"), str)
+        and contact["hasEmail"] != contact["hasEmail"].strip()
+        for contact in contact_list
+    ):
+        return dataset
+
+    new_dataset = copy.deepcopy(dataset)
+    new_contacts = new_dataset["contactPoint"]
+    new_contact_list = [new_contacts] if isinstance(new_contacts, dict) else new_contacts
+    for contact in new_contact_list:
+        if isinstance(contact, dict) and isinstance(contact.get("hasEmail"), str):
+            contact["hasEmail"] = contact["hasEmail"].strip()
     return new_dataset
 
 
@@ -281,8 +340,9 @@ def transform_temporal(dataset: dict) -> dict:
     """Convert `temporal` from an ISO 8601 interval string to a list
     containing one PeriodOfTime. Whichever side(s) parse as a date
     become startDate/endDate; non-date sides (durations or anything
-    else) are dropped. No-op if `temporal` isn't a string with one '/'
-    or if neither side parses."""
+    else) are dropped. No-op if `temporal` isn't a string with one '/'.
+    If neither side parses, `temporal` is set to None rather than left
+    as an invalid string."""
     value = dataset.get("temporal")
     if not isinstance(value, str):
         return dataset
@@ -298,7 +358,9 @@ def transform_temporal(dataset: dict) -> dict:
     start = _as_date(left)
     end = _as_date(right)
     if start is None and end is None:
-        return dataset
+        new_dataset = copy.deepcopy(dataset)
+        new_dataset["temporal"] = None
+        return new_dataset
 
     period = {"@type": "PeriodOfTime"}
     if start is not None:


### PR DESCRIPTION
Closes GSA/data.gov#6272, closes #166

EPA (Ellen D'Amico) reported 4 conversion failures in #166 with a working patch attached. Verified each against the current transforms.py:

- `theme` as a bare string: no transform existed, fails validation (theme is null-or-array in v3.0, no bare-string form). Added `transform_theme`, mirroring the existing `transform_rights` pattern.
- `contactPoint.hasEmail` with trailing whitespace: no transform existed, fails the mailto: format check. Added `transform_email`, handling contactPoint as both a single Kind object and a list of them.
- `language` as a bare string: `_truncate_language` silently no-ops on non-list input, so an untruncated tag like "en-US" fails v3.0's 2-char maxLength. `transform_language` now wraps a bare string in a list first.
- `temporal` where neither side of the interval parses: was left as an invalid raw string. Now set to None, since temporal is nullable in v3.0 but not allowed to be an arbitrary string.

Adapted from Ellen's patch with two changes: `transform_theme` unsets theme on other invalid types (dict, number) rather than leaving it broken, matching transform_rights; `transform_email` also handles contactPoint as a list, not just a single object.

## Test plan
- [x] `poetry run pytest tests/test_transforms.py` from `jsonschema/` — 106 passed (includes new TestTransformTheme, TestTransformEmail, plus updated cases for the language/temporal fixes)